### PR TITLE
fix: always edit SoundTouchSdkPrivateCfg.xml directly — Override ignored by firmware

### DIFF
--- a/apps/backend/src/opencloudtouch/devices/health_check.py
+++ b/apps/backend/src/opencloudtouch/devices/health_check.py
@@ -143,7 +143,6 @@ class DeviceHealthCheck:
         try:
             # Check BMX URL (Strategy A: direct URL change)
             result = await client.execute(
-                "cat /mnt/nv/SoundTouchSdkPrivateCfg.xml 2>/dev/null || "
                 "cat /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml "
                 "| grep -i bmxRegistryUrl"
             )

--- a/apps/backend/src/opencloudtouch/setup/config_service.py
+++ b/apps/backend/src/opencloudtouch/setup/config_service.py
@@ -67,12 +67,16 @@ class ConfigDiff:
 class SoundTouchConfigService:
     """Service for modifying SoundTouch device configuration."""
 
-    # Probed in order — first existing file wins
+    # Canonical config path — always edit directly (with remount rw).
+    # OverrideSdkPrivateCfg.xml is deliberately excluded: firmware on
+    # SoundTouch 10, 300 and other models ignores it entirely.
+    # See: gesellix/Bose-SoundTouch#220, scheilch/opencloudtouch#139
     CONFIG_CANDIDATES = [
-        "/mnt/nv/OverrideSdkPrivateCfg.xml",
         "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml",
-        "/mnt/nv/SoundTouchSdkPrivateCfg.xml",
     ]
+
+    # Stale override file that must be cleaned up (firmware ignores it)
+    _STALE_OVERRIDE = "/mnt/nv/OverrideSdkPrivateCfg.xml"
     BACKUP_DIR = "/mnt/nv"
 
     def __init__(self, ssh: SoundTouchSSHClient):
@@ -168,24 +172,10 @@ class SoundTouchConfigService:
     async def _write_config(self, content: str) -> None:
         """Write config file atomically via base64 piping.
 
-        If the detected config path is on a read-only filesystem
-        (/opt/Bose/etc/), copies to /mnt/nv/ first and writes there.
+        Writes directly to the canonical path (/opt/Bose/etc/).
+        Caller MUST have remounted rw before calling this.
         """
         path = await self._detect_config_path()
-
-        # If path is on read-only /opt/Bose/etc/, we need to write to /mnt/nv/
-        if path.startswith("/opt/Bose/"):
-            filename = path.rsplit("/", 1)[-1]
-            writable_path = f"/mnt/nv/{filename}"
-            # Copy original to writable location first (if not already there)
-            check = await self.ssh.execute(
-                f"test -f {writable_path} && echo 'exists' || echo 'missing'"
-            )
-            if "missing" in (check.output or ""):
-                await self.ssh.execute(f"cp {path} {writable_path}")
-            self.config_path = writable_path
-            path = writable_path
-            self.logger.info(f"Read-only filesystem detected, writing to {path}")
 
         b64 = base64.b64encode(content.encode()).decode()
         write_cmd = (
@@ -216,6 +206,19 @@ class SoundTouchConfigService:
             if not result.success:
                 self.logger.warning(f"Backup may have failed: {result.error}")
 
+    async def _cleanup_stale_override(self) -> None:
+        """Remove stale OverrideSdkPrivateCfg.xml if it exists.
+
+        Firmware on SoundTouch 10/300 ignores this file, but its presence
+        can confuse other tools or verification checks.
+        """
+        check = await self.ssh.execute(
+            f"test -f {self._STALE_OVERRIDE} && echo 'found' || echo 'missing'"
+        )
+        if "found" in (check.output or ""):
+            self.logger.info(f"Removing stale override: {self._STALE_OVERRIDE}")
+            await self.ssh.execute(f"rm -f {self._STALE_OVERRIDE}")
+
     async def modify_bmx_url(self, oct_ip: str) -> ModifyResult:
         """Modify BMX URL (and optionally marge/swupdate) in config.
 
@@ -239,6 +242,10 @@ class SoundTouchConfigService:
                 config_filename = (await self._detect_config_path()).rsplit("/", 1)[-1]
                 backup_path = f"{self.BACKUP_DIR}/{config_filename}.oct-backup"
                 await self._ensure_backup(backup_path)
+
+                # 2b. Remove stale OverrideSdkPrivateCfg.xml if present
+                # (firmware ignores it, but its presence may confuse verification)
+                await self._cleanup_stale_override()
 
                 # 3. Modify XML tags
                 diff = ConfigDiff()

--- a/apps/backend/src/opencloudtouch/setup/service.py
+++ b/apps/backend/src/opencloudtouch/setup/service.py
@@ -225,24 +225,17 @@ class SetupService:
     ) -> bool:
         """Write the new BMX URL into device config.
 
+        Always edits /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml directly
+        after remounting rw. The OverrideSdkPrivateCfg.xml approach does NOT
+        work on SoundTouch 10/300 (firmware ignores it).
+
         Returns:
             True if the step failed (caller should abort), False on success.
         """
-        result = await client.execute(
-            "test -w /opt/Bose/etc && echo 'writable' || echo 'readonly'"
-        )
+        config_path = "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
 
-        if "readonly" in (result.output or ""):
-            logger.info("Root filesystem is read-only, using override mechanism")
-            await client.execute(
-                "cp /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml /mnt/nv/SoundTouchSdkPrivateCfg.xml"
-            )
-            config_path = "/mnt/nv/SoundTouchSdkPrivateCfg.xml"
-            logger.warning(
-                "Config written to /mnt/nv - may need additional override setup"
-            )
-        else:
-            config_path = "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
+        # Remount rw — required for editing /opt/Bose/etc/
+        await client.execute("mount -o remount,rw /")
 
         sed_cmd = (
             f"sed -i 's|<bmxRegistryUrl>.*</bmxRegistryUrl>|"
@@ -263,8 +256,6 @@ class SetupService:
     ) -> None:
         """Verify that the BMX URL was written correctly (best-effort log only)."""
         result = await client.execute(
-            "cat /mnt/nv/OverrideSdkPrivateCfg.xml 2>/dev/null || "
-            "cat /mnt/nv/SoundTouchSdkPrivateCfg.xml 2>/dev/null || "
             "cat /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml | grep -i bmxRegistryUrl"
         )
         if new_bmx_url in (result.output or ""):
@@ -315,7 +306,6 @@ class SetupService:
 
             # Check BMX URL
             check = await client.execute(
-                "cat /mnt/nv/SoundTouchSdkPrivateCfg.xml 2>/dev/null || "
                 "cat /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml | grep -i bmxRegistryUrl"
             )
             result["bmx_url"] = check.output.strip()

--- a/apps/backend/tests/unit/setup/test_config_service.py
+++ b/apps/backend/tests/unit/setup/test_config_service.py
@@ -70,7 +70,7 @@ def mock_ssh():
 def service(mock_ssh):
     svc = SoundTouchConfigService(mock_ssh)
     # Pre-set config path to avoid extra SSH probe in every test
-    svc.config_path = "/mnt/nv/OverrideSdkPrivateCfg.xml"
+    svc.config_path = "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
     return svc
 
 
@@ -80,62 +80,32 @@ def service(mock_ssh):
 
 
 class TestConfigPath:
-    """Config path auto-detection tests (replaces BUG-03 regression)."""
+    """Config path auto-detection tests."""
 
     @pytest.fixture
     def fresh_service(self, mock_ssh):
         """Service without pre-set config_path for detection tests."""
         return SoundTouchConfigService(mock_ssh)
 
-    def test_first_candidate_is_mnt_nv_override(self):
+    def test_only_candidate_is_opt_bose(self):
         assert (
             SoundTouchConfigService.CONFIG_CANDIDATES[0]
-            == "/mnt/nv/OverrideSdkPrivateCfg.xml"
-        )
-
-    def test_second_candidate_is_opt_bose(self):
-        assert (
-            SoundTouchConfigService.CONFIG_CANDIDATES[1]
             == "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
         )
 
-    def test_third_candidate_is_mnt_nv_soundtouch(self):
-        assert (
-            SoundTouchConfigService.CONFIG_CANDIDATES[2]
-            == "/mnt/nv/SoundTouchSdkPrivateCfg.xml"
-        )
+    def test_only_one_candidate(self):
+        assert len(SoundTouchConfigService.CONFIG_CANDIDATES) == 1
 
     def test_backup_dir_is_on_persistent_volume(self):
         """Backups must be on persistent volume so they survive reboots."""
         assert SoundTouchConfigService.BACKUP_DIR == "/mnt/nv"
 
     @pytest.mark.asyncio
-    async def test_detect_first_candidate(self, fresh_service, mock_ssh):
-        """Detects /mnt/nv/OverrideSdkPrivateCfg.xml when it exists."""
+    async def test_detect_canonical_path(self, fresh_service, mock_ssh):
+        """Detects /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml."""
         mock_ssh.execute.return_value = _ok("found")
         path = await fresh_service._detect_config_path()
-        assert path == "/mnt/nv/OverrideSdkPrivateCfg.xml"
-
-    @pytest.mark.asyncio
-    async def test_detect_fallback_to_opt_bose(self, fresh_service, mock_ssh):
-        """Falls back to /opt/Bose/etc/ when /mnt/nv/ doesn't have the file."""
-        mock_ssh.execute.side_effect = [
-            _ok("missing"),  # /mnt/nv/OverrideSdkPrivateCfg.xml
-            _ok("found"),  # /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml
-        ]
-        path = await fresh_service._detect_config_path()
         assert path == "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
-
-    @pytest.mark.asyncio
-    async def test_detect_fallback_to_mnt_nv_soundtouch(self, fresh_service, mock_ssh):
-        """Falls back to /mnt/nv/SoundTouchSdkPrivateCfg.xml as last resort."""
-        mock_ssh.execute.side_effect = [
-            _ok("missing"),
-            _ok("missing"),
-            _ok("found"),
-        ]
-        path = await fresh_service._detect_config_path()
-        assert path == "/mnt/nv/SoundTouchSdkPrivateCfg.xml"
 
     @pytest.mark.asyncio
     async def test_detect_raises_when_none_found(self, fresh_service, mock_ssh):
@@ -151,7 +121,7 @@ class TestConfigPath:
         await fresh_service._detect_config_path()
         mock_ssh.execute.reset_mock()
         path = await fresh_service._detect_config_path()
-        assert path == "/mnt/nv/OverrideSdkPrivateCfg.xml"
+        assert path == "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
         mock_ssh.execute.assert_not_called()
 
 
@@ -285,12 +255,13 @@ class TestModifyBmxUrl:
 
     @pytest.mark.asyncio
     async def test_happy_path_modifies_bmx_url(self, service, mock_ssh):
-        """Full flow: remount rw → read → backup → modify → write → verify → remount ro."""
+        """Full flow: remount rw → read → backup → cleanup stale → write → verify → remount ro."""
         mock_ssh.execute.side_effect = [
             _ok(),  # remount rw
             _ok(SAMPLE_CONFIG_XML),  # read config (cat)
             _ok("missing"),  # backup check (test -f → missing)
             _ok(),  # cp backup
+            _ok("missing"),  # stale override check
             _ok(),  # write config (base64 pipe)
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify read-back
             _ok(),  # remount ro
@@ -322,6 +293,7 @@ class TestModifyBmxUrl:
             _ok(SAMPLE_CONFIG_XML),  # read config
             _ok("missing"),  # backup check
             _ok(),  # cp backup
+            _ok("missing"),  # stale override check
             _ok(),  # write config
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
             _ok(),  # remount ro
@@ -341,6 +313,7 @@ class TestModifyBmxUrl:
             _ok(),  # remount rw
             _ok(SAMPLE_CONFIG_XML),  # read config
             _ok("exists"),  # backup check → already exists
+            _ok("missing"),  # stale override check
             _ok(),  # write config
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
             _ok(),  # remount ro
@@ -361,6 +334,7 @@ class TestModifyBmxUrl:
             _ok(),  # remount rw
             _ok(SAMPLE_CONFIG_XML),  # read config
             _ok("exists"),  # backup exists
+            _ok("missing"),  # stale override check
             _ok(),  # write config
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
             _ok(),  # remount ro
@@ -368,8 +342,8 @@ class TestModifyBmxUrl:
 
         await service.modify_bmx_url("192.168.1.50")
 
-        # Find the write command (index 3: remount, read, backup_check, write)
-        write_cmd = mock_ssh.execute.call_args_list[3][0][0]
+        # Find the write command (index 4: remount, read, backup_check, stale_check, write)
+        write_cmd = mock_ssh.execute.call_args_list[4][0][0]
         assert "base64 -d" in write_cmd
         assert "/tmp/config.new" in write_cmd
         assert "mv /tmp/config.new" in write_cmd
@@ -381,6 +355,7 @@ class TestModifyBmxUrl:
             _ok(),  # remount rw
             _ok(SAMPLE_CONFIG_XML),  # read config
             _ok("exists"),  # backup exists
+            _ok("missing"),  # stale override check
             _ok(),  # write config
             _ok("corrupted garbage"),  # verify → missing closing tag!
             _ok(),  # remount ro
@@ -398,6 +373,7 @@ class TestModifyBmxUrl:
             _ok(),  # remount rw
             _ok(SAMPLE_CONFIG_XML),  # read config
             _ok("exists"),  # backup exists
+            _ok("missing"),  # stale override check
             _ok(),  # write config
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
             _ok(),  # remount ro
@@ -448,6 +424,7 @@ class TestModifyBmxUrl:
             _ok(),  # remount rw
             _ok(minimal_xml),  # read config
             _ok("exists"),  # backup check
+            _ok("missing"),  # stale override check
             _ok(),  # remount ro (no write — no changes)
         ]
 
@@ -463,6 +440,7 @@ class TestModifyBmxUrl:
             _ok(),  # remount rw
             _ok(SAMPLE_CONFIG_XML),  # read config
             _ok("exists"),  # backup check
+            _ok("missing"),  # stale override check
             _ok(),  # write config
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
             _ok(),  # remount ro
@@ -482,6 +460,7 @@ class TestModifyBmxUrl:
             _ok(),  # remount rw
             _ok(SAMPLE_CONFIG_XML),  # read config
             _ok("exists"),  # backup check
+            _ok("missing"),  # stale override check
             _ok(),  # write config
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
             _ok(),  # remount ro
@@ -490,7 +469,7 @@ class TestModifyBmxUrl:
         await service.modify_bmx_url("192.168.1.50")
 
         # Find the write command and decode the base64 content
-        write_cmd = mock_ssh.execute.call_args_list[3][0][0]
+        write_cmd = mock_ssh.execute.call_args_list[4][0][0]
         # Extract base64 string from: echo 'BASE64' | base64 -d > ...
         import base64 as b64
 
@@ -713,10 +692,7 @@ SAMPLE_OPT_BOSE_CONFIG = """\
 
 
 class TestModifyWithOptBosePath:
-    """Full modify flow when config is at /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml.
-
-    Regression test for GitHub issue #78.
-    """
+    """Full modify flow when config is at /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml."""
 
     @pytest.fixture
     def opt_service(self, mock_ssh):
@@ -725,42 +701,23 @@ class TestModifyWithOptBosePath:
         return svc
 
     @pytest.mark.asyncio
-    async def test_write_redirects_to_writable_mnt_nv(self, opt_service, mock_ssh):
-        """When config is on read-only /opt/Bose/etc/, write must go to /mnt/nv/."""
+    async def test_writes_directly_to_opt_bose(self, opt_service, mock_ssh):
+        """Config must be written directly to /opt/Bose/etc/ (no /mnt/nv/ copy)."""
         mock_ssh.execute.side_effect = [
             _ok(),  # remount rw
             _ok(SAMPLE_OPT_BOSE_CONFIG),  # read config (cat)
             _ok("missing"),  # backup check
             _ok(),  # cp backup
-            _ok("missing"),  # _write_config: check /mnt/nv/ copy
-            _ok(),  # _write_config: cp to /mnt/nv/
-            _ok(),  # _write_config: base64 write
+            _ok("missing"),  # stale override check
+            _ok(),  # write config (base64 pipe)
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify: cat
             _ok(),  # remount ro
         ]
 
         result = await opt_service.modify_bmx_url("192.168.1.50")
         assert result.success is True
-        assert opt_service.config_path == "/mnt/nv/SoundTouchSdkPrivateCfg.xml"
-
-    @pytest.mark.asyncio
-    async def test_reuses_existing_writable_copy(self, opt_service, mock_ssh):
-        """If /mnt/nv/ copy already exists, skip the cp from /opt/Bose/."""
-        mock_ssh.execute.side_effect = [
-            _ok(),  # remount rw
-            _ok(SAMPLE_OPT_BOSE_CONFIG),  # read config
-            _ok("exists"),  # backup exists
-            _ok("exists"),  # _write_config: writable copy exists
-            _ok(),  # _write_config: base64 write
-            _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
-            _ok(),  # remount ro
-        ]
-
-        result = await opt_service.modify_bmx_url("192.168.1.50")
-        assert result.success is True
-
-        all_cmds = [c[0][0] for c in mock_ssh.execute.call_args_list]
-        assert not any(c.startswith("cp /opt/Bose/") for c in all_cmds)
+        # Path must NOT have been redirected to /mnt/nv/
+        assert opt_service.config_path == "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
 
     @pytest.mark.asyncio
     async def test_backup_uses_detected_filename(self, opt_service, mock_ssh):
@@ -770,8 +727,7 @@ class TestModifyWithOptBosePath:
             _ok(SAMPLE_OPT_BOSE_CONFIG),  # read config
             _ok("missing"),  # backup check
             _ok(),  # cp backup
-            _ok("missing"),  # writable copy check
-            _ok(),  # cp to writable
+            _ok("missing"),  # stale override check
             _ok(),  # base64 write
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
             _ok(),  # remount ro
@@ -788,7 +744,7 @@ class TestModifyWithOptBosePath:
             _ok(),  # remount rw
             _ok(SAMPLE_OPT_BOSE_CONFIG),  # read config
             _ok("exists"),  # backup exists
-            _ok("exists"),  # writable copy exists
+            _ok("missing"),  # stale override check
             _ok(),  # write
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
             _ok(),  # remount ro
@@ -800,16 +756,17 @@ class TestModifyWithOptBosePath:
         assert "https://streaming.bose.com" in result.diff
 
 
-class TestModifyWithMntNvOverridePath:
-    """Full modify flow with /mnt/nv/OverrideSdkPrivateCfg.xml (standard path)."""
+class TestModifyDirectWrite:
+    """Verify modify writes directly to canonical path."""
 
     @pytest.mark.asyncio
     async def test_writes_directly_no_copy(self, service, mock_ssh):
-        """Config on /mnt/nv/ is writable — no copy needed."""
+        """Config is written directly to /opt/Bose/etc/ — no copy to /mnt/nv/."""
         mock_ssh.execute.side_effect = [
             _ok(),  # remount rw
             _ok(SAMPLE_CONFIG_XML),  # read config
             _ok("exists"),  # backup exists
+            _ok("missing"),  # stale override check
             _ok(),  # write config (direct)
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
             _ok(),  # remount ro
@@ -819,31 +776,35 @@ class TestModifyWithMntNvOverridePath:
         assert result.success is True
 
         all_cmds = [c[0][0] for c in mock_ssh.execute.call_args_list]
-        assert not any(c.startswith("cp /opt/Bose/") for c in all_cmds)
+        # No cp to /mnt/nv/ should exist
+        cp_to_mnt = [c for c in all_cmds if "cp" in c and "/mnt/nv/SoundTouch" in c]
+        assert len(cp_to_mnt) == 0
 
     @pytest.mark.asyncio
-    async def test_backup_uses_override_filename(self, service, mock_ssh):
-        """Backup must be named OverrideSdkPrivateCfg.xml.oct-backup."""
+    async def test_backup_uses_canonical_filename(self, service, mock_ssh):
+        """Backup must be named SoundTouchSdkPrivateCfg.xml.oct-backup."""
         mock_ssh.execute.side_effect = [
             _ok(),  # remount rw
             _ok(SAMPLE_CONFIG_XML),  # read config
             _ok("missing"),  # backup check
             _ok(),  # cp backup
+            _ok("missing"),  # stale override check
             _ok(),  # write config
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
             _ok(),  # remount ro
         ]
 
         result = await service.modify_bmx_url("192.168.1.50")
-        assert result.backup_path == "/mnt/nv/OverrideSdkPrivateCfg.xml.oct-backup"
+        assert result.backup_path == "/mnt/nv/SoundTouchSdkPrivateCfg.xml.oct-backup"
 
     @pytest.mark.asyncio
-    async def test_write_targets_mnt_nv_directly(self, service, mock_ssh):
-        """Write command must target /mnt/nv/ directly."""
+    async def test_write_targets_opt_bose_directly(self, service, mock_ssh):
+        """Write command must target /opt/Bose/etc/ directly."""
         mock_ssh.execute.side_effect = [
             _ok(),  # remount rw
             _ok(SAMPLE_CONFIG_XML),  # read config
             _ok("exists"),  # backup exists
+            _ok("missing"),  # stale override check
             _ok(),  # write config
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
             _ok(),  # remount ro
@@ -851,57 +812,32 @@ class TestModifyWithMntNvOverridePath:
 
         await service.modify_bmx_url("192.168.1.50")
 
-        write_cmd = mock_ssh.execute.call_args_list[3][0][0]
-        assert "/mnt/nv/OverrideSdkPrivateCfg.xml" in write_cmd
+        write_cmd = mock_ssh.execute.call_args_list[4][0][0]
+        assert "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml" in write_cmd
 
 
-class TestRestoreWithOptBosePath:
-    """Restore flow when config was moved from /opt/Bose/etc/ to /mnt/nv/."""
-
-    @pytest.fixture
-    def opt_service(self, mock_ssh):
-        svc = SoundTouchConfigService(mock_ssh)
-        svc.config_path = "/mnt/nv/SoundTouchSdkPrivateCfg.xml"
-        return svc
+class TestRestoreWithCanonicalPath:
+    """Restore flow with canonical /opt/Bose/etc/ path."""
 
     @pytest.mark.asyncio
-    async def test_restore_targets_detected_path(self, opt_service, mock_ssh):
-        """Restore must copy to the detected (writable) config path."""
+    async def test_restore_targets_canonical_path(self, service, mock_ssh):
+        """Restore must copy to /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml."""
         mock_ssh.execute.side_effect = [
             _ok("exists"),  # backup check
             _ok(),  # remount rw
-            _ok(),  # cp backup → /mnt/nv/SoundTouchSdkPrivateCfg.xml
+            _ok(),  # cp backup → /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml
             _ok(SAMPLE_OPT_BOSE_CONFIG),  # verify
             _ok(),  # remount ro
         ]
 
-        result = await opt_service.restore_config(
+        result = await service.restore_config(
             "/mnt/nv/SoundTouchSdkPrivateCfg.xml.oct-backup"
         )
         assert result.success is True
 
         cp_cmd = mock_ssh.execute.call_args_list[2][0][0]
-        assert "/mnt/nv/SoundTouchSdkPrivateCfg.xml" in cp_cmd
+        assert "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml" in cp_cmd
         assert "oct-backup" in cp_cmd
-
-    @pytest.mark.asyncio
-    async def test_restore_with_override_path(self, service, mock_ssh):
-        """Restore must target /mnt/nv/OverrideSdkPrivateCfg.xml for standard path."""
-        mock_ssh.execute.side_effect = [
-            _ok("exists"),  # backup check
-            _ok(),  # remount rw
-            _ok(),  # cp backup → /mnt/nv/OverrideSdkPrivateCfg.xml
-            _ok(SAMPLE_CONFIG_XML),  # verify
-            _ok(),  # remount ro
-        ]
-
-        result = await service.restore_config(
-            "/mnt/nv/OverrideSdkPrivateCfg.xml.oct-backup"
-        )
-        assert result.success is True
-
-        cp_cmd = mock_ssh.execute.call_args_list[2][0][0]
-        assert "/mnt/nv/OverrideSdkPrivateCfg.xml" in cp_cmd
 
 
 class TestDetectConfigPathFullFlow:
@@ -912,14 +848,15 @@ class TestDetectConfigPathFullFlow:
         return SoundTouchConfigService(mock_ssh)
 
     @pytest.mark.asyncio
-    async def test_first_candidate_found(self, fresh, mock_ssh):
-        """Full flow when /mnt/nv/OverrideSdkPrivateCfg.xml is found."""
+    async def test_canonical_path_found(self, fresh, mock_ssh):
+        """Full flow when /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml is found."""
         mock_ssh.execute.side_effect = [
             _ok(),  # remount rw
-            _ok("found"),  # probe: /mnt/nv/OverrideSdkPrivateCfg.xml
-            _ok(SAMPLE_CONFIG_XML),  # cat config
+            _ok("found"),  # probe: /opt/Bose/etc/ → found
+            _ok(SAMPLE_OPT_BOSE_CONFIG),  # cat config
             _ok("missing"),  # backup check
             _ok(),  # cp backup
+            _ok("missing"),  # stale override check
             _ok(),  # write config
             _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify: cat
             _ok(),  # remount ro
@@ -927,42 +864,133 @@ class TestDetectConfigPathFullFlow:
 
         result = await fresh.modify_bmx_url("192.168.1.50")
         assert result.success is True
-        assert fresh.config_path == "/mnt/nv/OverrideSdkPrivateCfg.xml"
-        assert result.backup_path == "/mnt/nv/OverrideSdkPrivateCfg.xml.oct-backup"
-
-    @pytest.mark.asyncio
-    async def test_second_candidate_found(self, fresh, mock_ssh):
-        """Full flow when only /opt/Bose/etc/ config exists."""
-        mock_ssh.execute.side_effect = [
-            _ok(),  # remount rw
-            _ok("missing"),  # probe 1: /mnt/nv/Override → miss
-            _ok("found"),  # probe 2: /opt/Bose/etc/ → found
-            _ok(SAMPLE_OPT_BOSE_CONFIG),  # cat config
-            _ok("missing"),  # backup check
-            _ok(),  # cp backup
-            _ok("missing"),  # _write_config: writable copy check
-            _ok(),  # _write_config: cp to /mnt/nv/
-            _ok(),  # _write_config: base64 write
-            _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify: cat
-            _ok(),  # remount ro
-        ]
-
-        result = await fresh.modify_bmx_url("192.168.1.50")
-        assert result.success is True
-        assert fresh.config_path == "/mnt/nv/SoundTouchSdkPrivateCfg.xml"
+        assert fresh.config_path == "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
         assert result.backup_path == "/mnt/nv/SoundTouchSdkPrivateCfg.xml.oct-backup"
 
     @pytest.mark.asyncio
     async def test_no_config_found(self, fresh, mock_ssh):
-        """All probes fail → returns failure."""
+        """Probe fails → returns failure."""
         mock_ssh.execute.side_effect = [
             _ok(),  # remount rw
-            _ok("missing"),  # probe 1
-            _ok("missing"),  # probe 2
-            _ok("missing"),  # probe 3
+            _ok("missing"),  # probe: /opt/Bose/etc/ → miss
             _ok(),  # remount ro (finally)
         ]
 
         result = await fresh.modify_bmx_url("192.168.1.50")
         assert result.success is False
         assert "Config file not found" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Regression: OverrideSdkPrivateCfg.xml ignored by firmware (Issue #139 / PR #220)
+#
+# SoundTouch 10, 300 and other models ignore OverrideSdkPrivateCfg.xml entirely.
+# OCT must always write directly to /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml.
+# See: github.com/gesellix/Bose-SoundTouch/pull/220
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideConfigIgnoredByFirmware:
+    """Regression tests: firmware ignores OverrideSdkPrivateCfg.xml on some models.
+
+    The fix removes OverrideSdkPrivateCfg.xml from CONFIG_CANDIDATES entirely
+    and always edits /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml directly.
+    """
+
+    def test_config_candidates_no_override_file(self):
+        """OverrideSdkPrivateCfg.xml must NOT be in candidates — firmware ignores it."""
+        for candidate in SoundTouchConfigService.CONFIG_CANDIDATES:
+            assert "OverrideSdkPrivateCfg" not in candidate, (
+                f"Override config {candidate} must be removed — "
+                "firmware on ST10/ST300 ignores it (gesellix/Bose-SoundTouch#220)"
+            )
+
+    def test_config_candidates_starts_with_opt_bose(self):
+        """Primary config path must be /opt/Bose/etc/SoundTouchSdkPrivateCfg.xml."""
+        assert SoundTouchConfigService.CONFIG_CANDIDATES[0] == (
+            "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
+        )
+
+    def test_config_candidates_no_mnt_nv_copy(self):
+        """/mnt/nv/SoundTouchSdkPrivateCfg.xml must NOT be a candidate.
+
+        Writing to /mnt/nv/ doesn't work — the device reads from /opt/Bose/etc/
+        on boot. Only direct edit of the original works reliably.
+        """
+        for candidate in SoundTouchConfigService.CONFIG_CANDIDATES:
+            if candidate.startswith("/mnt/nv/"):
+                pytest.fail(
+                    f"Candidate {candidate} is on /mnt/nv/ — device ignores this path"
+                )
+
+    @pytest.fixture
+    def fresh_service(self, mock_ssh):
+        return SoundTouchConfigService(mock_ssh)
+
+    @pytest.mark.asyncio
+    async def test_detect_finds_opt_bose_directly(self, fresh_service, mock_ssh):
+        """Detection must resolve to /opt/Bose/etc/ path."""
+        mock_ssh.execute.return_value = _ok("found")
+        path = await fresh_service._detect_config_path()
+        assert path == "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
+
+    @pytest.mark.asyncio
+    async def test_write_targets_opt_bose_directly(self, fresh_service, mock_ssh):
+        """Write must go to /opt/Bose/etc/ directly — no copy to /mnt/nv/."""
+        fresh_service.config_path = "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
+        mock_ssh.execute.return_value = _ok()
+
+        await fresh_service._write_config("<SoundTouchSdkPrivateCfg/>")
+
+        write_cmd = mock_ssh.execute.call_args_list[0][0][0]
+        assert "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml" in write_cmd
+        # Must NOT redirect to /mnt/nv/
+        assert "/mnt/nv/" not in write_cmd
+
+    @pytest.mark.asyncio
+    async def test_modify_cleans_stale_override(self, fresh_service, mock_ssh):
+        """If stale OverrideSdkPrivateCfg.xml exists, it must be removed."""
+        mock_ssh.execute.side_effect = [
+            _ok(),  # remount rw
+            _ok("found"),  # probe: /opt/Bose/etc/ found
+            _ok(SAMPLE_OPT_BOSE_CONFIG),  # read config
+            _ok("missing"),  # backup check
+            _ok(),  # cp backup
+            _ok("found"),  # check stale override exists
+            _ok(),  # rm stale override
+            _ok(),  # write config
+            _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
+            _ok(),  # remount ro
+        ]
+
+        result = await fresh_service.modify_bmx_url("192.168.1.50")
+        assert result.success is True
+
+        all_cmds = [c[0][0] for c in mock_ssh.execute.call_args_list]
+        # Must have removed the stale override
+        rm_cmds = [c for c in all_cmds if "rm" in c and "Override" in c]
+        assert len(rm_cmds) > 0, "Stale OverrideSdkPrivateCfg.xml must be removed"
+
+    @pytest.mark.asyncio
+    async def test_full_flow_writes_to_canonical_path(self, fresh_service, mock_ssh):
+        """End-to-end: config is always written to /opt/Bose/etc/."""
+        fresh_service.config_path = "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml"
+        mock_ssh.execute.side_effect = [
+            _ok(),  # remount rw
+            _ok(SAMPLE_OPT_BOSE_CONFIG),  # read config
+            _ok("exists"),  # backup exists
+            _ok("missing"),  # check stale override → not present
+            _ok(),  # write config
+            _ok(SAMPLE_CONFIG_ALREADY_MODIFIED),  # verify
+            _ok(),  # remount ro
+        ]
+
+        result = await fresh_service.modify_bmx_url("192.168.1.50")
+        assert result.success is True
+
+        # The write command must target /opt/Bose/etc/
+        write_cmds = [
+            c[0][0] for c in mock_ssh.execute.call_args_list if "base64" in c[0][0]
+        ]
+        assert len(write_cmds) == 1
+        assert "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml" in write_cmds[0]

--- a/apps/backend/tests/unit/setup/test_service.py
+++ b/apps/backend/tests/unit/setup/test_service.py
@@ -296,14 +296,17 @@ class TestSetupServiceInternalMethods:
         assert mock_client.execute.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_apply_bmx_url_readonly_filesystem(self, service):
-        """_apply_bmx_url uses /mnt/nv path when filesystem is readonly (lines 210-215)."""
+    async def test_apply_bmx_url_always_remounts_and_edits_directly(self, service):
+        """_apply_bmx_url must remount rw and edit /opt/Bose/etc/ directly.
+
+        Regression: readonly fallback to /mnt/nv/ doesn't work — firmware ignores it.
+        See: gesellix/Bose-SoundTouch#220, scheilch/opencloudtouch#139
+        """
         mock_client = MagicMock()
         mock_client.execute = AsyncMock(
             side_effect=[
-                MagicMock(success=True, output="readonly"),  # test -w → readonly
-                MagicMock(success=True, output=""),  # cp to /mnt/nv
-                MagicMock(success=True, output=""),  # sed on /mnt/nv path
+                MagicMock(success=True, output=""),  # remount rw
+                MagicMock(success=True, output=""),  # sed on /opt/Bose/etc/ path
             ]
         )
 
@@ -312,19 +315,59 @@ class TestSetupServiceInternalMethods:
 
         failed = await service._apply_bmx_url(
             mock_client,
-            "http://localhost:8000/bmx/registry/v1/services",
+            "http://content.api.bose.io:7777/bmx/registry/v1/services",
             noop_progress,
             MagicMock(),
         )
-        assert failed is False  # should succeed
+        assert failed is False
+
+        # Must have remounted rw
+        first_cmd = mock_client.execute.call_args_list[0][0][0]
+        assert "remount,rw" in first_cmd
+
+        # sed must target /opt/Bose/etc/ directly
+        sed_cmd = mock_client.execute.call_args_list[1][0][0]
+        assert "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml" in sed_cmd
+        assert "/mnt/nv/" not in sed_cmd
 
     @pytest.mark.asyncio
-    async def test_apply_bmx_url_sed_fails_returns_true(self, service):
-        """_apply_bmx_url returns True (failed) when sed command fails (lines 227-232)."""
+    async def test_apply_bmx_url_no_readonly_fallback(self, service):
+        """_apply_bmx_url must NOT copy to /mnt/nv/ as fallback.
+
+        Regression: firmware on ST10/ST300 ignores files on /mnt/nv/.
+        """
         mock_client = MagicMock()
         mock_client.execute = AsyncMock(
             side_effect=[
-                MagicMock(success=True, output="writable"),  # test -w → writable
+                MagicMock(success=True, output=""),  # remount rw
+                MagicMock(success=True, output=""),  # sed
+            ]
+        )
+
+        async def noop_progress(step, msg, **kwargs):
+            pass
+
+        await service._apply_bmx_url(
+            mock_client,
+            "http://content.api.bose.io:7777/bmx/registry/v1/services",
+            noop_progress,
+            MagicMock(),
+        )
+
+        all_cmds = [c[0][0] for c in mock_client.execute.call_args_list]
+        # No cp to /mnt/nv should exist
+        cp_to_mnt_nv = [c for c in all_cmds if "cp" in c and "/mnt/nv/" in c]
+        assert (
+            len(cp_to_mnt_nv) == 0
+        ), "Must NOT copy config to /mnt/nv/ — firmware ignores it"
+
+    @pytest.mark.asyncio
+    async def test_apply_bmx_url_sed_fails_returns_true(self, service):
+        """_apply_bmx_url returns True (failed) when sed command fails."""
+        mock_client = MagicMock()
+        mock_client.execute = AsyncMock(
+            side_effect=[
+                MagicMock(success=True, output=""),  # remount rw
                 MagicMock(success=False, error="sed: no such file"),  # sed fails
             ]
         )
@@ -335,7 +378,7 @@ class TestSetupServiceInternalMethods:
 
         failed = await service._apply_bmx_url(
             mock_client,
-            "http://localhost:8000/bmx",
+            "http://content.api.bose.io:7777/bmx",
             track_progress,
             MagicMock(),
         )
@@ -343,10 +386,72 @@ class TestSetupServiceInternalMethods:
         assert len(progress_calls) == 1
 
     @pytest.mark.asyncio
-    async def test_run_setup_apply_bmx_fails_returns_early(self, service):
-        """run_setup closes client and returns early when _apply_bmx_url fails (lines 123-124)."""
+    async def test_verify_bmx_url_reads_canonical_path(self, service):
+        """_verify_bmx_url must read from /opt/Bose/etc/ path only.
+
+        Regression: OverrideSdkPrivateCfg.xml is ignored by firmware.
+        """
         mock_client = MagicMock()
-        # execute call ordering: touch, ls, mkdir, cp×2, test-w, sed(fails)
+        bmx_url = "http://content.api.bose.io:7777/bmx/registry/v1/services"
+        mock_client.execute = AsyncMock(
+            return_value=MagicMock(
+                success=True, output=f"<bmxRegistryUrl>{bmx_url}</bmxRegistryUrl>"
+            )
+        )
+
+        await service._verify_bmx_url(mock_client, bmx_url)
+
+        verify_cmd = mock_client.execute.call_args_list[0][0][0]
+        assert "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml" in verify_cmd
+        # Must NOT check OverrideSdkPrivateCfg.xml
+        assert "OverrideSdkPrivateCfg" not in verify_cmd
+
+    @pytest.mark.asyncio
+    async def test_verify_setup_reads_canonical_config_path(self, service):
+        """verify_setup must read BMX URL from /opt/Bose/etc/ path.
+
+        Regression: /mnt/nv/ paths are unreliable.
+        """
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock()
+        mock_client.execute = AsyncMock(
+            side_effect=[
+                MagicMock(output="yes", success=True),  # SSH persistence
+                MagicMock(
+                    output="<bmxRegistryUrl>http://localhost:8000/bmx</bmxRegistryUrl>",
+                    success=True,
+                ),  # BMX check
+            ]
+        )
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "opencloudtouch.setup.service.check_ssh_port",
+            new_callable=AsyncMock,
+            return_value=True,
+        ), patch(
+            "opencloudtouch.setup.service.SoundTouchSSHClient", return_value=mock_client
+        ), patch(
+            "opencloudtouch.setup.service.get_config"
+        ) as cfg_mock:
+            cfg_mock.return_value.station_descriptor_base_url = None
+            cfg_mock.return_value.server_url = "http://localhost:8000"
+            cfg_mock.return_value.host = "localhost"
+            cfg_mock.return_value.port = 8000
+
+            await service.verify_setup("192.168.1.100")
+
+        # The BMX check command
+        bmx_cmd = mock_client.execute.call_args_list[1][0][0]
+        assert "/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml" in bmx_cmd
+        # Must NOT reference Override path or /mnt/nv/ variants
+        assert "OverrideSdkPrivateCfg" not in bmx_cmd
+
+    @pytest.mark.asyncio
+    async def test_run_setup_apply_bmx_fails_returns_early(self, service):
+        """run_setup closes client and returns early when _apply_bmx_url fails."""
+        mock_client = MagicMock()
+        # execute call ordering: touch, ls, mkdir, cp×2, remount-rw, sed(fails)
         mock_client.connect = AsyncMock(return_value=MagicMock(success=True))
         mock_client.execute = AsyncMock(
             side_effect=[
@@ -355,7 +460,7 @@ class TestSetupServiceInternalMethods:
                 MagicMock(success=True, output=""),  # mkdir backup
                 MagicMock(success=True, output=""),  # cp config 1
                 MagicMock(success=True, output=""),  # cp config 2
-                MagicMock(success=True, output="writable"),  # test -w
+                MagicMock(success=True, output=""),  # remount rw
                 MagicMock(
                     success=False, error="sed: failed"
                 ),  # sed fails → failed=True
@@ -373,7 +478,7 @@ class TestSetupServiceInternalMethods:
             )
 
         mock_client.close.assert_called()
-        # Progress should be in FAILED state (sed fails → _apply_bmx_url returns True → early return)
+        # Progress should be in FAILED state
         assert progress is not None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
﻿## Problem

Firmware on SoundTouch 10, 300 and other models **ignores** `OverrideSdkPrivateCfg.xml` entirely. OCT previously probed for this file first, so config writes had no effect on affected devices — the BMX registry URL was never actually changed, and preset playback failed silently.

Additionally, the readonly-fallback that copied the config to `/mnt/nv/` also doesn't work — the firmware only reads from `/opt/Bose/etc/`.

See: [gesellix/Bose-SoundTouch#220](https://github.com/gesellix/Bose-SoundTouch/pull/220) for independent confirmation.

## Root Cause

`CONFIG_CANDIDATES` in `config_service.py` listed `/mnt/nv/OverrideSdkPrivateCfg.xml` as priority-1 candidate. If any other tool had created that file, OCT would write there — but firmware ignores it. Similarly, `service.py._apply_bmx_url` had a readonly-fallback copying to `/mnt/nv/`, which is equally ignored.

## Changes

**config_service.py:**
- `CONFIG_CANDIDATES` reduced to only `/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml`
- `_write_config` writes directly to canonical path (no /mnt/nv/ redirect)
- Added `_cleanup_stale_override` to remove leftover `OverrideSdkPrivateCfg.xml`

**service.py:**
- `_apply_bmx_url` now remounts rw + edits `/opt/Bose/etc/` directly (no writable-check fallback)
- `_verify_bmx_url` reads canonical path only
- `verify_setup` reads canonical path only

**health_check.py:**
- Config check reads `/opt/Bose/etc/` only

## Tests

- 7 new regression tests in `test_config_service.py`
- 5 new regression tests in `test_service.py`
- All 1213 backend unit tests pass
- Pre-commit hooks: all green

## Verification

Tested with TDD Red-Green cycle. All existing tests updated to match new behavior.

Relates to #139
