### PR TITLE
fix: resolve device_id from margeAccountUUID instead of hardcoded value (#188)

### DIFF
--- a/apps/backend/src/opencloudtouch/devices/repository.py
+++ b/apps/backend/src/opencloudtouch/devices/repository.py
@@ -31,6 +31,7 @@ class Device:
         setup_status: str = "unknown",
         ssh_permanent: bool = False,
         setup_completed_at: Optional[datetime] = None,
+        marge_account_uuid: Optional[str] = None,
     ):
         self.id = id
         self.device_id = device_id
@@ -46,6 +47,7 @@ class Device:
         self.setup_status = setup_status
         self.ssh_permanent = ssh_permanent
         self.setup_completed_at = setup_completed_at
+        self.marge_account_uuid = marge_account_uuid
 
     @staticmethod
     def _extract_schema_version(firmware_version: str) -> str:
@@ -81,6 +83,7 @@ class Device:
             "setup_completed_at": (
                 self.setup_completed_at.isoformat() if self.setup_completed_at else None
             ),
+            "marge_account_uuid": self.marge_account_uuid,
         }
 
 
@@ -131,6 +134,11 @@ class DeviceRepository(BaseRepository):
             description="Add setup_completed_at column to devices",
             sql="ALTER TABLE devices ADD COLUMN setup_completed_at TIMESTAMP",
         )
+        await self._apply_migration(
+            version=103,
+            description="Add marge_account_uuid column to devices",
+            sql="ALTER TABLE devices ADD COLUMN marge_account_uuid TEXT",
+        )
 
         # Indexes
         await self._conn.execute("""
@@ -156,8 +164,8 @@ class DeviceRepository(BaseRepository):
 
         cursor = await db.execute(
             """
-            INSERT INTO devices (device_id, ip, name, model, mac_address, firmware_version, schema_version, last_seen)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO devices (device_id, ip, name, model, mac_address, firmware_version, schema_version, last_seen, marge_account_uuid)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(device_id) DO UPDATE SET
                 ip = excluded.ip,
                 name = excluded.name,
@@ -165,6 +173,7 @@ class DeviceRepository(BaseRepository):
                 firmware_version = excluded.firmware_version,
                 schema_version = excluded.schema_version,
                 last_seen = excluded.last_seen,
+                marge_account_uuid = COALESCE(excluded.marge_account_uuid, devices.marge_account_uuid),
                 updated_at = CURRENT_TIMESTAMP
             RETURNING id
         """,
@@ -177,6 +186,7 @@ class DeviceRepository(BaseRepository):
                 device.firmware_version,
                 device.schema_version,
                 device.last_seen,
+                device.marge_account_uuid,
             ),
         )
 
@@ -195,7 +205,7 @@ class DeviceRepository(BaseRepository):
         cursor = await db.execute("""
             SELECT id, device_id, ip, name, model, mac_address, firmware_version,
                    schema_version, last_seen, setup_status, ssh_permanent,
-                   setup_completed_at
+                   setup_completed_at, marge_account_uuid
             FROM devices
             ORDER BY last_seen DESC
         """)
@@ -211,7 +221,7 @@ class DeviceRepository(BaseRepository):
             """
             SELECT id, device_id, ip, name, model, mac_address, firmware_version,
                    schema_version, last_seen, setup_status, ssh_permanent,
-                   setup_completed_at
+                   setup_completed_at, marge_account_uuid
             FROM devices
             WHERE device_id = ?
         """,
@@ -257,6 +267,38 @@ class DeviceRepository(BaseRepository):
         await db.commit()
         logger.info(f"Updated setup status for {device_id}: {setup_status}")
 
+    async def get_by_marge_account_uuid(
+        self, marge_account_uuid: str
+    ) -> Optional[Device]:
+        """Get device by its marge account UUID (margeAccountUUID).
+
+        This is the account ID that SoundTouch devices use when calling
+        /streaming/account/{account_id}/full on boot.
+
+        Args:
+            marge_account_uuid: The account UUID (e.g., "5522049")
+
+        Returns:
+            Device if found, None otherwise
+        """
+        db = self._ensure_initialized()
+
+        cursor = await db.execute(
+            """
+            SELECT id, device_id, ip, name, model, mac_address, firmware_version,
+                   schema_version, last_seen, setup_status, ssh_permanent,
+                   setup_completed_at, marge_account_uuid
+            FROM devices
+            WHERE marge_account_uuid = ?
+        """,
+            (marge_account_uuid,),
+        )
+
+        row = await cursor.fetchone()
+        if not row:
+            return None
+        return self._row_to_device(row)
+
     async def delete_all(self) -> int:
         """Delete all devices from database. Returns number of deleted rows."""
         db = self._ensure_initialized()
@@ -275,7 +317,7 @@ class DeviceRepository(BaseRepository):
 
         Column order: id, device_id, ip, name, model, mac_address,
         firmware_version, schema_version, last_seen, setup_status,
-        ssh_permanent, setup_completed_at.
+        ssh_permanent, setup_completed_at, marge_account_uuid.
         """
         return Device(
             id=row[0],
@@ -290,4 +332,5 @@ class DeviceRepository(BaseRepository):
             setup_status=row[9] or "unknown",
             ssh_permanent=bool(row[10]) if row[10] is not None else False,
             setup_completed_at=(datetime.fromisoformat(row[11]) if row[11] else None),
+            marge_account_uuid=row[12] if len(row) > 12 else None,
         )

--- a/apps/backend/src/opencloudtouch/devices/services/sync_service.py
+++ b/apps/backend/src/opencloudtouch/devices/services/sync_service.py
@@ -283,6 +283,9 @@ class DeviceSyncService:
         """
         Query device for detailed info via /info endpoint.
 
+        Also fetches the margeAccountUUID from the device so that
+        /streaming/account/{account_id}/full can resolve the correct device.
+
         Args:
             discovered: Discovered device with base URL
 
@@ -295,6 +298,9 @@ class DeviceSyncService:
         client = get_device_client(discovered.base_url)
         info = await client.get_info()
 
+        # Fetch margeAccountUUID separately (parsed from /info XML)
+        marge_uuid = await self._fetch_marge_account_uuid(discovered.ip)
+
         return Device(
             device_id=info.device_id,
             ip=discovered.ip,
@@ -302,4 +308,28 @@ class DeviceSyncService:
             model=info.type,
             mac_address=info.mac_address,
             firmware_version=info.firmware_version,
+            marge_account_uuid=marge_uuid,
         )
+
+    @staticmethod
+    async def _fetch_marge_account_uuid(device_ip: str) -> Optional[str]:
+        """Fetch margeAccountUUID from device /info endpoint.
+
+        Uses the existing account_pairing_service function which
+        parses the raw /info XML for the <margeAccountUUID> element.
+
+        Returns:
+            The UUID string if present, None otherwise.
+            Never raises — logs warnings on failure.
+        """
+        try:
+            from opencloudtouch.setup.account_pairing_service import (
+                check_marge_account_uuid,
+            )
+
+            return await check_marge_account_uuid(device_ip)
+        except Exception:
+            logger.debug(
+                "Could not fetch margeAccountUUID from %s", device_ip, exc_info=True
+            )
+            return None

--- a/apps/backend/src/opencloudtouch/marge/routes.py
+++ b/apps/backend/src/opencloudtouch/marge/routes.py
@@ -8,9 +8,11 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import Response
 
 from opencloudtouch.core.dependencies import (
+    get_device_repo,
     get_preset_repository,
     get_recents_repository,
 )
+from opencloudtouch.devices.repository import DeviceRepository
 from opencloudtouch.marge.xml_builder import (
     build_devices_xml,
     build_full_account_xml,
@@ -271,32 +273,49 @@ async def streaming_sourceproviders() -> Response:
 async def streaming_full_account(
     account_id: str,
     preset_repo: PresetRepository = Depends(get_preset_repository),
+    device_repo: DeviceRepository = Depends(get_device_repo),
 ) -> Response:
     """Get full account sync via streaming endpoint.
 
     This is the streaming.bose.com version of the account sync endpoint.
-    Returns complete account with all devices, presets, recents, and sources.
+    Resolves the device_id from the account_id (margeAccountUUID) stored
+    during device discovery, then returns that device's presets.
 
     Args:
-        account_id: Account ID (e.g., "3784726")
+        account_id: Marge account UUID (e.g., "5522049")
         preset_repo: Preset repository dependency
+        device_repo: Device repository dependency
 
     Returns:
         XML Response with <account> structure
     """
     logger.info("[MARGE/STREAMING] Full account sync for account %s", account_id)
 
-    # For now, return a generic device_id. In future, map account_id to device.
-    # The device ID is typically its MAC address.
-    device_id = "689E194F7D2F"  # TODO: Get from account mapping
+    # Resolve device_id from margeAccountUUID (fixes #188)
+    device = await device_repo.get_by_marge_account_uuid(account_id)
+    if not device:
+        logger.warning(
+            "[MARGE/STREAMING] No device found for account %s — "
+            "returning empty presets. Device may not have been synced yet.",
+            account_id,
+        )
+        return _xml_response(build_full_account_xml([], []), _MEDIA_STREAMING_XML)
+
+    device_id = device.device_id
+    logger.info(
+        "[MARGE/STREAMING] Resolved account %s → device %s",
+        account_id,
+        device_id,
+    )
 
     # Load presets from database
     presets = await preset_repo.get_all_presets(device_id)
 
     logger.info(
-        "[MARGE/STREAMING] Returning %d presets for account %s",
+        "[MARGE/STREAMING] Returning %d presets for account %s (device %s)",
         len(presets),
         account_id,
+        device_id,
     )
 
     return _xml_response(build_full_account_xml(presets, []), _MEDIA_STREAMING_XML)

--- a/apps/backend/tests/regression/test_bugfixes.py
+++ b/apps/backend/tests/regression/test_bugfixes.py
@@ -399,6 +399,11 @@ class TestNoDeviceCountLimit:
             "opencloudtouch.devices.services.sync_service.get_device_client",
             mock_client,
         )
+        monkeypatch.setattr(
+            DeviceSyncService,
+            "_fetch_marge_account_uuid",
+            staticmethod(AsyncMock(return_value=None)),
+        )
 
         repo = AsyncMock()
         repo.upsert = AsyncMock()
@@ -448,3 +453,77 @@ class TestBugfix003RadioSearchImportIncomplete:
         # - Tests verify error handling executes without import errors
         # - Tests verify ERROR_503 displays "Dienst nicht verfügbar"
         assert True, "RadioSearch error handling coverage exists in E2E suite"
+
+
+class TestBugfix188HardcodedDeviceIdInStreamingAccount:
+    """
+    BUGFIX 188: /streaming/account/{account_id}/full used hardcoded device_id.
+
+    Date: 2026-05-12
+    Issue: https://github.com/scheilch/opencloudtouch/issues/188
+    Reporter: Zimbo88
+    Symptom: Device boots, calls /streaming/account/5522049/full,
+             receives empty presets because code used hardcoded
+             device_id="689E194F7D2F" instead of resolving via
+             margeAccountUUID mapping.
+    Root Cause: streaming_full_account() had a TODO comment and
+                hardcoded device_id instead of looking up the device
+                by its margeAccountUUID from the database.
+    Fix: - Added marge_account_uuid column to devices table
+         - Sync service fetches UUID from device /info on discovery
+         - streaming_full_account resolves device via DB lookup
+    """
+
+    def test_no_hardcoded_device_id_in_streaming_route(self):
+        """Ensure streaming_full_account does not contain hardcoded device IDs."""
+        import inspect
+        from opencloudtouch.marge.routes import streaming_full_account
+
+        source = inspect.getsource(streaming_full_account)
+        assert (
+            "689E194F7D2F" not in source
+        ), "streaming_full_account must not contain hardcoded device ID"
+        assert "# TODO: Get from account mapping" not in source
+
+    @pytest.mark.asyncio
+    async def test_resolves_device_by_account_uuid(self):
+        """Account UUID maps to correct device → presets loaded for that device."""
+        from opencloudtouch.marge.routes import streaming_full_account
+
+        mock_device = MagicMock()
+        mock_device.device_id = "10CEA9A6FA71"
+
+        mock_device_repo = AsyncMock()
+        mock_device_repo.get_by_marge_account_uuid = AsyncMock(return_value=mock_device)
+
+        mock_preset_repo = AsyncMock()
+        mock_preset_repo.get_all_presets = AsyncMock(return_value=[])
+
+        await streaming_full_account("5522049", mock_preset_repo, mock_device_repo)
+
+        # Must have looked up by account UUID, not used hardcoded ID
+        mock_device_repo.get_by_marge_account_uuid.assert_called_once_with("5522049")
+        # Must have loaded presets for the RESOLVED device
+        mock_preset_repo.get_all_presets.assert_called_once_with("10CEA9A6FA71")
+
+    @pytest.mark.asyncio
+    async def test_unknown_account_returns_empty_not_crash(self):
+        """Unknown account UUID → empty presets, no crash, no guessing."""
+        from opencloudtouch.marge.routes import streaming_full_account
+        from xml.etree import ElementTree
+
+        mock_device_repo = AsyncMock()
+        mock_device_repo.get_by_marge_account_uuid = AsyncMock(return_value=None)
+
+        mock_preset_repo = AsyncMock()
+
+        result = await streaming_full_account(
+            "UNKNOWN", mock_preset_repo, mock_device_repo
+        )
+
+        assert result.status_code == 200
+        root = ElementTree.fromstring(result.body.decode())
+        presets = root.find("presets")
+        assert len(presets.findall("preset")) == 0
+        # Must NOT have tried to load presets with some guessed device
+        mock_preset_repo.get_all_presets.assert_not_called()

--- a/apps/backend/tests/unit/marge/test_streaming_routes.py
+++ b/apps/backend/tests/unit/marge/test_streaming_routes.py
@@ -117,28 +117,65 @@ class TestStreamingSourceproviders:
 
 
 class TestStreamingFullAccount:
+    """Tests for /streaming/account/{account_id}/full (fixes #188)."""
+
+    def _make_device_repo(self, device=None):
+        """Create mock device_repo that returns given device for UUID lookup."""
+        mock = AsyncMock()
+        mock.get_by_marge_account_uuid = AsyncMock(return_value=device)
+        return mock
+
+    def _make_device(self, device_id="689E194F7D2F"):
+        """Create a mock device with given device_id."""
+        device = MagicMock()
+        device.device_id = device_id
+        return device
+
     @pytest.mark.asyncio
-    async def test_returns_200_with_empty_presets(self):
+    async def test_returns_presets_for_mapped_device(self):
+        """Account UUID resolves to device → returns that device's presets."""
+        device = self._make_device("10CEA9A6FA71")
+        device_repo = self._make_device_repo(device)
+
         mock_preset_repo = AsyncMock()
         mock_preset_repo.get_all_presets = AsyncMock(return_value=[])
 
-        result = await streaming_full_account("3784726", mock_preset_repo)
+        result = await streaming_full_account("5522049", mock_preset_repo, device_repo)
         assert result.status_code == 200
+        mock_preset_repo.get_all_presets.assert_called_once_with("10CEA9A6FA71")
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_device_mapping(self):
+        """No device found for account UUID → empty presets, no crash."""
+        device_repo = self._make_device_repo(None)
+        mock_preset_repo = AsyncMock()
+
+        result = await streaming_full_account("9999999", mock_preset_repo, device_repo)
+        assert result.status_code == 200
+        root = ElementTree.fromstring(result.body.decode())
+        presets = root.find("presets")
+        assert presets is not None
+        assert len(presets.findall("preset")) == 0
+        mock_preset_repo.get_all_presets.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_media_type_is_bose_streaming(self):
+        device = self._make_device()
+        device_repo = self._make_device_repo(device)
         mock_preset_repo = AsyncMock()
         mock_preset_repo.get_all_presets = AsyncMock(return_value=[])
 
-        result = await streaming_full_account("3784726", mock_preset_repo)
+        result = await streaming_full_account("3784726", mock_preset_repo, device_repo)
         assert "bose.streaming" in result.media_type
 
     @pytest.mark.asyncio
     async def test_returns_bose_account_xml(self):
+        device = self._make_device()
+        device_repo = self._make_device_repo(device)
         mock_preset_repo = AsyncMock()
         mock_preset_repo.get_all_presets = AsyncMock(return_value=[])
 
-        result = await streaming_full_account("3784726", mock_preset_repo)
+        result = await streaming_full_account("3784726", mock_preset_repo, device_repo)
         root = ElementTree.fromstring(result.body.decode())
         assert root.tag == "boseAccount"
 
@@ -153,10 +190,12 @@ class TestStreamingFullAccount:
         mock_preset.created_at.timestamp.return_value = 1234567890
         mock_preset.updated_at.timestamp.return_value = 1234567890
 
+        device = self._make_device()
+        device_repo = self._make_device_repo(device)
         mock_preset_repo = AsyncMock()
         mock_preset_repo.get_all_presets = AsyncMock(return_value=[mock_preset])
 
-        result = await streaming_full_account("3784726", mock_preset_repo)
+        result = await streaming_full_account("3784726", mock_preset_repo, device_repo)
         root = ElementTree.fromstring(result.body.decode())
         presets = root.find("presets")
         assert presets is not None


### PR DESCRIPTION
## Summary

Fixes #188 — `/streaming/account/{account_id}/full` returned empty presets because `device_id` was hardcoded to `689E194F7D2F`.

## Root Cause

The streaming account sync endpoint used a hardcoded device ID instead of resolving the actual device linked to the `margeAccountUUID`. Any device with a different MAC address would receive empty presets on boot, causing `INVALID_SOURCE` errors.

## Changes

### Backend (`apps/backend/`)

- **`devices/repository.py`**: Added `marge_account_uuid` field to `Device` model, DB migration v103, `get_by_marge_account_uuid()` lookup method, updated `upsert` with `COALESCE` to preserve existing UUIDs
- **`devices/services/sync_service.py`**: Fetch `margeAccountUUID` from device `/info` endpoint during every discovery sync cycle
- **`marge/routes.py`**: Replace hardcoded `device_id` with dynamic DB lookup via `device_repo.get_by_marge_account_uuid(account_id)`

### Tests

- **`tests/unit/marge/test_streaming_routes.py`**: Updated `TestStreamingFullAccount` for new `device_repo` parameter — tests mapped device, unmapped device, XML structure
- **`tests/regression/test_bugfixes.py`**: Added `TestBugfix188HardcodedDeviceIdInStreamingAccount` — static source analysis + runtime behavior tests

## Behavior Change

| Scenario | Before (v1.2.4) | After |
|---|---|---|
| Device with UUID `5522049` calls endpoint | Returns presets for hardcoded `689E194F7D2F` (wrong) | Returns presets for correct device |
| Unknown account_id | Returns 0 presets (silent) | Returns 0 presets + warning log |
| All other endpoints | unchanged | unchanged |

## Test Results

- 1405 passed, 1 skipped, 0 failed
- All pre-commit + pre-push hooks green
