### PR TITLE
feat: persistence init endpoint + contributors section (#167)

### DIFF
--- a/apps/backend/openapi.yaml
+++ b/apps/backend/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: OpenCloudTouch
   description: Open-Source replacement for discontinued streaming device cloud features
-  version: 1.2.6
+  version: dev-86ea3de
 paths:
   /api/devices/discover:
     get:
@@ -1297,9 +1297,8 @@ paths:
       description: "Get full account sync for device.\n\nThis endpoint is called by\
         \ SoundTouch devices on boot to sync:\n- Presets (6 buttons)\n- Recents (recently\
         \ played)\n- Sources (available sources)\n\nArgs:\n    device_id: Device MAC\
-        \ address (e.g., \"689E194F7D2F\")\n    preset_repo: Preset repository dependency\n\
-        \    recents_repo: Recents repository dependency\n\nReturns:\n    XML Response\
-        \ with <boseAccount> structure"
+        \ address (e.g., \"689E194F7D2F\")\n    marge: Marge service dependency\n\n\
+        Returns:\n    XML Response with <boseAccount> structure"
       operationId: get_full_account_v1_systems_devices__device_id__get
       parameters:
       - name: device_id
@@ -1326,8 +1325,8 @@ paths:
       - marge
       summary: Get Presets
       description: "Get presets for device.\n\nArgs:\n    device_id: Device MAC address\n\
-        \    preset_repo: Preset repository dependency\n\nReturns:\n    XML Response\
-        \ with <presets> structure"
+        \    marge: Marge service dependency\n\nReturns:\n    XML Response with <presets>\
+        \ structure"
       operationId: get_presets_v1_systems_devices__device_id__presets_get
       parameters:
       - name: device_id
@@ -1354,8 +1353,8 @@ paths:
       - marge
       summary: Get Recents
       description: "Get recently played items for device.\n\nArgs:\n    device_id:\
-        \ Device MAC address\n    recents_repo: Recents repository dependency\n\n\
-        Returns:\n    XML Response with <recents> structure"
+        \ Device MAC address\n    marge: Marge service dependency\n\nReturns:\n  \
+        \  XML Response with <recents> structure"
       operationId: get_recents_v1_systems_devices__device_id__recents_get
       parameters:
       - name: device_id
@@ -1565,10 +1564,10 @@ paths:
       - marge
       summary: Streaming Full Account
       description: "Get full account sync via streaming endpoint.\n\nThis is the streaming.bose.com\
-        \ version of the account sync endpoint.\nReturns complete account with all\
-        \ devices, presets, recents, and sources.\n\nArgs:\n    account_id: Account\
-        \ ID (e.g., \"3784726\")\n    preset_repo: Preset repository dependency\n\n\
-        Returns:\n    XML Response with <account> structure"
+        \ version of the account sync endpoint.\nResolves the device_id from the account_id\
+        \ (margeAccountUUID) stored\nduring device discovery, then returns that device's\
+        \ presets.\n\nArgs:\n    account_id: Account ID (e.g., \"3784726\")\n    marge:\
+        \ Marge service dependency\n\nReturns:\n    XML Response with <account> structure"
       operationId: streaming_full_account_streaming_account__account_id__full_get
       parameters:
       - name: account_id
@@ -1640,7 +1639,8 @@ paths:
       summary: Streaming Token
       description: "Return a dummy streaming token for device authentication.\n\n\
         SoundTouch firmware 27.x requests this token before playing a preset.\nIf\
-        \ the request fails, the device aborts playback with INVALID_SOURCE.\n\nArgs:\n\
+        \ the request fails, the device aborts playback with INVALID_SOURCE.\nThe\
+        \ token value is not validated — any non-empty response suffices.\n\nArgs:\n\
         \    device_id: Device MAC address\n\nReturns:\n    JSON with a dummy access\
         \ token"
       operationId: streaming_token_streaming_device__device_id__streaming_token_get
@@ -1664,34 +1664,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
   /v1/blacklist/{device_id}:
-    get:
-      tags:
-      - marge
-      summary: Blacklist Check
-      description: "Content blacklist check — always returns empty (nothing blacklisted).\n\
-        \nThe device checks this before playing content. If the endpoint is\nunreachable,\
-        \ some firmware versions refuse playback.\n\nArgs:\n    device_id: Device\
-        \ MAC address\n\nReturns:\n    JSON with empty blacklist"
-      operationId: blacklist_check_v1_blacklist__device_id__get
-      parameters:
-      - name: device_id
-        in: path
-        required: true
-        schema:
-          type: string
-          title: Device Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
     post:
       tags:
       - marge
@@ -1720,6 +1692,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - marge
+      summary: Blacklist Check
+      description: "Content blacklist check — always returns empty (nothing blacklisted).\n\
+        \nThe device checks this before playing content. If the endpoint is\nunreachable,\
+        \ some firmware versions refuse playback.\n\nArgs:\n    device_id: Device\
+        \ MAC address\n\nReturns:\n    JSON with empty blacklist"
+      operationId: blacklist_check_v1_blacklist__device_id__get
+      parameters:
+      - name: device_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Device Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /setMargeAccount:
     post:
       tags:
@@ -1727,44 +1727,16 @@ paths:
       summary: Set Marge Account
       description: "Pair device with a Bose Cloud account (stub).\n\nThe SoundTouch\
         \ app calls this to associate a device with an account.\nOCT doesn't use real\
-        \ cloud accounts, but the device expects a 200 OK.\n\nReturns:\n    200 OK\
-        \ with status XML"
+        \ cloud accounts, but the device expects a 200 OK.\nThe actual margeAccountUUID\
+        \ is set via Telnet or device-side API.\n\nReturns:\n    200 OK with status\
+        \ XML"
       operationId: set_marge_account_setMargeAccount_post
       responses:
         '200':
           description: Successful Response
           content:
-            application/xml:
+            application/json:
               schema: {}
-  /api/setup/wizard/ensure-account:
-    post:
-      tags:
-      - setup-wizard
-      summary: Ensure Account UUID
-      description: "Ensure device has a margeAccountUUID (Wizard Step).\n\nDevices\
-        \ without a margeAccountUUID cannot play presets (INVALID_SOURCE).\nThis endpoint\
-        \ checks GET :8090/info and sets a UUID via Telnet if missing.\n\nSafe to\
-        \ call multiple times — no-op if UUID already present."
-      operationId: wizard_ensure_account_api_setup_wizard_ensure_account_post
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EnsureAccountRequest'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/EnsureAccountResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
   /playlist/{device_id}/{preset_number}.m3u:
     get:
       tags:
@@ -1895,7 +1867,7 @@ paths:
       tags:
       - Device Setup
       summary: Check Connectivity
-      description: 'Check if device is ready for setup (SSH/Telnet available).
+      description: 'Check if device is ready for setup (SSH available).
 
 
         This should be called after user inserts USB stick and reboots device.'
@@ -2101,7 +2073,7 @@ paths:
       tags:
       - Setup Wizard
       summary: Wizard Check Ports
-      description: Check if SSH/Telnet ports accessible (Wizard Step 3).
+      description: Check if SSH port is accessible (Wizard Step 3).
       operationId: wizard_check_ports_api_setup_wizard_check_ports_post
       requestBody:
         content:
@@ -2283,14 +2255,7 @@ paths:
       tags:
       - Setup Wizard
       summary: Wizard Reboot Device
-      description: 'Reboot SoundTouch device via SSH (Wizard Step 7).
-
-
-        Sends the `reboot` command via SSH. The device drops the SSH connection
-
-        immediately after receiving the command — this is expected and not an error.
-
-        Frontend should wait ~60s before attempting verify-redirect tests.'
+      description: Reboot SoundTouch device via SSH (Wizard Step 7).
       operationId: wizard_reboot_device_api_setup_wizard_reboot_device_post
       requestBody:
         content:
@@ -2307,37 +2272,6 @@ paths:
                 type: object
                 title: Response Wizard Reboot Device Api Setup Wizard Reboot Device
                   Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /api/setup/wizard/complete:
-    post:
-      tags:
-      - Setup Wizard
-      summary: Wizard Complete
-      description: 'Mark wizard setup as complete for a device.
-
-
-        Updates the device''s setup_status to ''configured'' in the database.
-
-        Called by the frontend when the user finishes the wizard.'
-      operationId: wizard_complete_api_setup_wizard_complete_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/WizardCompleteRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/WizardCompleteResponse'
         '422':
           description: Validation Error
           content:
@@ -2377,18 +2311,112 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/setup/wizard/ensure-account:
+    post:
+      tags:
+      - Setup Wizard
+      summary: Wizard Ensure Account
+      description: 'Ensure device has a margeAccountUUID (Wizard Step � after config/hosts).
+
+
+        Devices without a margeAccountUUID cannot play presets (INVALID_SOURCE).
+
+        This endpoint checks GET :8090/info and sets a UUID via Telnet if missing.
+
+
+        Safe to call multiple times � no-op if UUID already present.'
+      operationId: wizard_ensure_account_api_setup_wizard_ensure_account_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountPairingRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountPairingResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/setup/wizard/init-persistence:
+    post:
+      tags:
+      - Setup Wizard
+      summary: Wizard Init Persistence
+      description: 'Initialize persistence files on factory-reset devices (Wizard
+        Step — after account pairing).
+
+
+        Factory-reset devices lack SystemConfigurationDB.xml and Sources.xml.
+
+        Without them, the firmware never fully initialises playback state,
+
+        causing INVALID_SOURCE on preset recall (GitHub Issue #167).
+
+
+        Only creates files that are missing — never overwrites existing ones.
+
+        Safe to call multiple times.'
+      operationId: wizard_init_persistence_api_setup_wizard_init_persistence_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InitPersistenceRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InitPersistenceResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/setup/wizard/complete:
+    post:
+      tags:
+      - Setup Wizard
+      summary: Wizard Complete
+      description: Mark wizard setup as complete for a device.
+      operationId: wizard_complete_api_setup_wizard_complete_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WizardCompleteRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WizardCompleteResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/setup/wizard/verify-redirect:
     post:
       tags:
       - Setup Wizard
       summary: Wizard Verify Redirect
-      description: 'Verify a domain is redirected to OCT on the device (Wizard Step
+      description: Verify a domain is redirected to OCT on the device (Wizard Step
         7).
-
-
-        SSH into the device, run ping against the domain, and check whether
-
-        the resolved IP matches the OCT server''s IP.'
       operationId: wizard_verify_redirect_api_setup_wizard_verify_redirect_post
       requestBody:
         content:
@@ -2417,9 +2445,9 @@ paths:
       description: 'Return firmware INDEX.XML for SoundTouch devices.
 
 
-        The device checks this endpoint at boot and periodically
+        Serves the original Bose worldwide.bose.com index so devices recognise
 
-        to determine if a firmware update is available.'
+        their current firmware as up-to-date and don''t attempt downloads.'
       operationId: firmware_index_updates_soundtouch_get
       responses:
         '200':
@@ -2431,23 +2459,9 @@ paths:
     get:
       tags:
       - swupdate
-      summary: Firmware Download
-      description: 'Redirect firmware download to device.
-
-
-        Firmware files are large (100+ MB). Instead of hosting them,
-
-        we return a 404 — OCT intentionally does NOT serve firmware
-
-        updates to prevent devices from updating to versions that
-
-        might break OCT compatibility.
-
-
-        In the future, this could proxy to archive.org for
-
-        specific firmware versions needed for downgrading.'
-      operationId: firmware_download_ced_eup_downloads_rel__filename__get
+      summary: Firmware Download Legacy
+      description: Block legacy firmware download path.
+      operationId: firmware_download_legacy_ced_eup_downloads_rel__filename__get
       parameters:
       - name: filename
         in: path
@@ -2472,9 +2486,14 @@ paths:
       tags:
       - swupdate
       summary: Firmware Download
-      description: 'Block real Bose firmware download path (Stockholm devices).
+      description: 'Block real Bose firmware download path.
 
-        Returns 404 to prevent unintended firmware updates.'
+
+        The real index XML references https://downloads.bose.com/ced/soundtouch/...
+
+        but since swUpdateUrl points to OCT, the device may try to fetch from here.
+
+        We return 404 to prevent unintended firmware updates.'
       operationId: firmware_download_ced_soundtouch_downloads_stockholm__path__get
       parameters:
       - name: path
@@ -2512,6 +2531,8 @@ paths:
                   $ref: '#/components/schemas/ZoneStatus'
                 type: array
                 title: Response Get All Zones Api Zones Get
+        '500':
+          description: Failed to get zones
     post:
       tags:
       - Zones
@@ -2683,6 +2704,217 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/logs/level:
+    get:
+      tags:
+      - logs
+      summary: Get current log level
+      operationId: get_log_level_api_logs_level_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogLevelResponse'
+    put:
+      tags:
+      - logs
+      summary: Set log level at runtime
+      operationId: put_log_level_api_logs_level_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LogLevelRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogLevelResponse'
+        '400':
+          description: Invalid log level
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/logs/backend:
+    get:
+      tags:
+      - logs
+      summary: Download backend log buffer (without frontend logs)
+      description: Returns backend logs only. Use POST to include frontend console
+        logs.
+      operationId: download_backend_logs_get_api_logs_backend_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/plain:
+              schema:
+                type: string
+    post:
+      tags:
+      - logs
+      summary: Download backend + frontend logs
+      description: Returns backend logs with frontend console logs included.
+      operationId: download_backend_logs_post_api_logs_backend_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LogDownloadRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/plain:
+              schema:
+                type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/bug-report:
+    post:
+      tags:
+      - bug-report
+      summary: Create Bug Report
+      description: Create a bug report as a GitHub Issue with auto-collected diagnostics.
+      operationId: create_bug_report_api_bug_report_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BugReportRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BugReportResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/bug-report/diagnostics:
+    post:
+      tags:
+      - bug-report
+      summary: Download Diagnostics
+      description: 'Download a gzipped diagnostic bundle — works without GitHub token.
+
+
+        The user can drag-drop the .log.gz file into a manually created GitHub issue.'
+      operationId: download_diagnostics_api_bug_report_diagnostics_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DiagnosticsRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/wizard/audit-log:
+    post:
+      tags:
+      - Wizard Audit
+      summary: Post Audit Entry
+      description: Record a single wizard audit log entry.
+      operationId: post_audit_entry_api_wizard_audit_log_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuditEntryRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditEntryResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/wizard/audit-log/batch:
+    post:
+      tags:
+      - Wizard Audit
+      summary: Post Audit Batch
+      description: Record multiple wizard audit log entries in one request.
+      operationId: post_audit_batch_api_wizard_audit_log_batch_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuditBatchRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditBatchResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/wizard/config-snapshot:
+    post:
+      tags:
+      - Wizard Audit
+      summary: Post Config Snapshot
+      description: Store a config XML snapshot.
+      operationId: post_config_snapshot_api_wizard_config_snapshot_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfigSnapshotRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigSnapshotResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /health:
     get:
       tags:
@@ -2696,207 +2928,133 @@ paths:
           content:
             application/json:
               schema: {}
-  /api/logs/level:
-    get:
-      tags:
-        - logs
-      summary: Get current log level
-      operationId: get_log_level_api_logs_level_get
-      responses:
-        '200':
-          description: Current log level
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LogLevelResponse'
-    put:
-      tags:
-        - logs
-      summary: Set log level at runtime
-      operationId: put_log_level_api_logs_level_put
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LogLevelRequest'
-      responses:
-        '200':
-          description: Updated log level
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LogLevelResponse'
-        '400':
-          description: Invalid log level
-  /api/logs/backend:
-    get:
-      tags:
-        - logs
-      summary: Download Backend Log
-      description: Returns the in-memory backend log as a plain-text file download.
-      operationId: download_backend_log_api_logs_backend_get
-      responses:
-        '200':
-          description: Plain-text log file download
-          content:
-            text/plain:
-              schema:
-                type: string
-    post:
-      tags:
-        - logs
-      summary: Download Logs with Frontend Console
-      description: Returns backend + frontend console logs as a plain-text file download.
-      operationId: download_backend_log_api_logs_backend_post
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LogDownloadRequest'
-      responses:
-        '200':
-          description: Plain-text log file download
-          content:
-            text/plain:
-              schema:
-                type: string
-  /api/bug-report:
-    post:
-      tags:
-        - bug-report
-      summary: Submit Bug Report
-      description: Submit a bug report that creates a GitHub issue with diagnostic data.
-      operationId: submit_bug_report_api_bug_report_post
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/BugReportRequest'
-      responses:
-        '200':
-          description: Bug report submitted successfully
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BugReportResponse'
-        '503':
-          description: GitHub token not configured
-  /api/bug-report/diagnostics:
-    post:
-      tags:
-        - bug-report
-      summary: Download Diagnostics
-      description: Download a gzipped diagnostic bundle without requiring a GitHub token.
-      operationId: download_diagnostics_api_bug_report_diagnostics_post
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DiagnosticsRequest'
-      responses:
-        '200':
-          description: Gzipped diagnostic log file
-          content:
-            application/gzip:
-              schema:
-                type: string
-                format: binary
-  /api/wizard/audit-log:
-    post:
-      tags:
-        - Wizard Audit
-      summary: Post Audit Entry
-      description: Record a single wizard audit log entry.
-      operationId: post_audit_entry_api_wizard_audit_log_post
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuditEntryRequest'
-      responses:
-        '200':
-          description: Entry recorded
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AuditEntryResponse'
-        '503':
-          description: Wizard audit repository not initialized
-  /api/wizard/audit-log/batch:
-    post:
-      tags:
-        - Wizard Audit
-      summary: Post Audit Batch
-      description: Record multiple wizard audit log entries in one request.
-      operationId: post_audit_batch_api_wizard_audit_log_batch_post
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuditBatchRequest'
-      responses:
-        '200':
-          description: Batch recorded
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AuditBatchResponse'
-        '503':
-          description: Wizard audit repository not initialized
-  /api/wizard/config-snapshot:
-    post:
-      tags:
-        - Wizard Audit
-      summary: Post Config Snapshot
-      description: Store a config XML snapshot for audit purposes.
-      operationId: post_config_snapshot_api_wizard_config_snapshot_post
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ConfigSnapshotRequest'
-      responses:
-        '200':
-          description: Snapshot stored
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConfigSnapshotResponse'
-        '503':
-          description: Wizard audit repository not initialized
 components:
   schemas:
-    LogLevelResponse:
+    AccountPairingRequest:
       properties:
-        level:
+        device_ip:
           type: string
-          title: Level
+          title: Device Ip
+          description: Device IP address
+        device_id:
+          type: string
+          title: Device Id
+          description: Device ID (MAC address)
       type: object
       required:
-      - level
-      title: LogLevelResponse
-    LogLevelRequest:
+      - device_ip
+      - device_id
+      title: AccountPairingRequest
+      description: Request to ensure device has a margeAccountUUID.
+    AccountPairingResponse:
       properties:
-        level:
+        success:
+          type: boolean
+          title: Success
+        had_uuid:
+          type: boolean
+          title: Had Uuid
+          description: True if UUID was already present
+          default: false
+        uuid:
           type: string
-          enum:
-          - DEBUG
-          - INFO
-          - WARNING
-          - ERROR
-          - CRITICAL
-          title: Level
+          title: Uuid
+          description: The current or newly set UUID
+          default: ''
+        message:
+          type: string
+          title: Message
+          default: ''
       type: object
       required:
-      - level
-      title: LogLevelRequest
+      - success
+      title: AccountPairingResponse
+      description: Response from account pairing.
+    AuditBatchRequest:
+      properties:
+        entries:
+          items:
+            $ref: '#/components/schemas/AuditEntryRequest'
+          type: array
+          maxItems: 200
+          minItems: 1
+          title: Entries
+      type: object
+      required:
+      - entries
+      title: AuditBatchRequest
+      description: Batch of audit entries (reduces HTTP roundtrips).
+    AuditBatchResponse:
+      properties:
+        success:
+          type: boolean
+          title: Success
+        count:
+          type: integer
+          title: Count
+      type: object
+      required:
+      - success
+      - count
+      title: AuditBatchResponse
+      description: Response for batch creation.
+    AuditEntryRequest:
+      properties:
+        device_id:
+          type: string
+          title: Device Id
+          description: Device MAC/ID
+        category:
+          type: string
+          title: Category
+          description: 'Event category: user_action, device_info, api_call, config_change,
+            step_transition, checkbox, dropdown, error'
+        event:
+          type: string
+          title: Event
+          description: Short event name, e.g. 'button_click:next'
+        step:
+          anyOf:
+          - type: integer
+            maximum: 7.0
+            minimum: 0.0
+          - type: 'null'
+          title: Step
+          description: Wizard step number (0=init)
+        detail:
+          anyOf:
+          - type: string
+            maxLength: 10000
+          - type: 'null'
+          title: Detail
+          description: JSON-encoded extra data (free-form)
+        timestamp:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Timestamp
+          description: ISO-8601 timestamp from frontend
+      type: object
+      required:
+      - device_id
+      - category
+      - event
+      title: AuditEntryRequest
+      description: Single wizard audit log entry from the frontend.
+    AuditEntryResponse:
+      properties:
+        success:
+          type: boolean
+          title: Success
+        id:
+          type: integer
+          title: Id
+      type: object
+      required:
+      - success
+      - id
+      title: AuditEntryResponse
+      description: Response for single entry creation.
     BackupRequest:
       properties:
         device_ip:
@@ -2908,7 +3066,6 @@ components:
           - type: 'null'
           title: Device Id
           description: Device identifier for unique backup filenames
-          default: null
       type: object
       required:
       - device_ip
@@ -2941,50 +3098,6 @@ components:
       - message
       title: BackupResponse
       description: Response with backup results.
-    BugReportRequest:
-      type: object
-      required:
-        - description
-        - steps_to_reproduce
-        - expected_behavior
-        - installation_type
-        - hardware
-      properties:
-        description:
-          type: string
-          minLength: 20
-        steps_to_reproduce:
-          type: string
-          minLength: 10
-        expected_behavior:
-          type: string
-          minLength: 10
-        installation_type:
-          type: string
-        hardware:
-          type: string
-        soundtouch_devices:
-          type: array
-          items:
-            type: string
-          default: []
-        other_installation:
-          type: string
-          default: ''
-        other_hardware:
-          type: string
-          default: ''
-      title: BugReportRequest
-    BugReportResponse:
-      type: object
-      properties:
-        issue_url:
-          type: string
-        issue_number:
-          type: integer
-        message:
-          type: string
-      title: BugReportResponse
     Body_set_mute_api_devices__device_id__mute_put:
       properties:
         muted:
@@ -3005,6 +3118,94 @@ components:
       required:
       - level
       title: Body_set_volume_api_devices__device_id__volume_put
+    BugReportRequest:
+      properties:
+        description:
+          type: string
+          maxLength: 2000
+          minLength: 10
+          title: Description
+        steps_to_reproduce:
+          type: string
+          maxLength: 2000
+          minLength: 10
+          title: Steps To Reproduce
+        expected_behavior:
+          type: string
+          maxLength: 1000
+          minLength: 5
+          title: Expected Behavior
+        installation_type:
+          type: string
+          title: Installation Type
+        hardware:
+          type: string
+          title: Hardware
+        soundtouch_devices:
+          items:
+            type: string
+          type: array
+          title: Soundtouch Devices
+          default: []
+        network_config:
+          type: string
+          title: Network Config
+          default: ''
+        additional_info:
+          type: string
+          title: Additional Info
+          default: ''
+        other_installation:
+          type: string
+          title: Other Installation
+          default: ''
+        other_hardware:
+          type: string
+          title: Other Hardware
+          default: ''
+        other_device:
+          type: string
+          title: Other Device
+          default: ''
+        screenshot_data_url:
+          type: string
+          title: Screenshot Data Url
+          default: ''
+        frontend_logs:
+          items:
+            type: object
+          type: array
+          title: Frontend Logs
+          default: []
+        browser_info:
+          type: string
+          title: Browser Info
+          default: ''
+        current_route:
+          type: string
+          title: Current Route
+          default: ''
+        click_timestamp:
+          type: number
+          title: Click Timestamp
+          default: 0.0
+      type: object
+      required:
+      - description
+      - steps_to_reproduce
+      - expected_behavior
+      - installation_type
+      - hardware
+      title: BugReportRequest
+    BugReportResponse:
+      properties:
+        issue_url:
+          type: string
+          title: Issue Url
+      type: object
+      required:
+      - issue_url
+      title: BugReportResponse
     ChangeMasterRequest:
       properties:
         new_master_id:
@@ -3060,6 +3261,52 @@ components:
       - message
       title: ConfigModifyResponse
       description: Response with config modification result.
+    ConfigSnapshotRequest:
+      properties:
+        device_id:
+          type: string
+          title: Device Id
+        file_path:
+          type: string
+          title: File Path
+          description: Config file path on device
+        content:
+          type: string
+          maxLength: 50000
+          title: Content
+          description: Full XML content
+        trigger:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Trigger
+          description: What caused the snapshot, e.g. 'before_modify'
+        timestamp:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Timestamp
+      type: object
+      required:
+      - device_id
+      - file_path
+      - content
+      title: ConfigSnapshotRequest
+      description: Request to store a config XML snapshot.
+    ConfigSnapshotResponse:
+      properties:
+        success:
+          type: boolean
+          title: Success
+        id:
+          type: integer
+          title: Id
+      type: object
+      required:
+      - success
+      - id
+      title: ConfigSnapshotResponse
+      description: Response for snapshot creation.
     ConnectivityCheckRequest:
       properties:
         ip:
@@ -3106,6 +3353,33 @@ components:
       - message
       title: DetectStrategyResponse
       description: Response with detected setup strategy.
+    DiagnosticsRequest:
+      properties:
+        frontend_logs:
+          items:
+            type: object
+          type: array
+          title: Frontend Logs
+          default: []
+        description:
+          type: string
+          title: Description
+          default: ''
+        browser_info:
+          type: string
+          title: Browser Info
+          default: ''
+        current_route:
+          type: string
+          title: Current Route
+          default: ''
+        click_timestamp:
+          type: number
+          title: Click Timestamp
+          default: 0.0
+      type: object
+      title: DiagnosticsRequest
+      description: Request body for diagnostics download (no GitHub token needed).
     EnablePermanentSSHRequest:
       properties:
         device_id:
@@ -3127,6 +3401,23 @@ components:
       - ip
       title: EnablePermanentSSHRequest
       description: Request to enable permanent SSH access on device.
+    FrontendLogEntry:
+      properties:
+        timestamp:
+          type: string
+          title: Timestamp
+          default: ''
+        level:
+          type: string
+          title: Level
+          default: ''
+        message:
+          type: string
+          title: Message
+          default: ''
+      type: object
+      title: FrontendLogEntry
+      description: A single frontend console log entry.
     HTTPValidationError:
       properties:
         detail:
@@ -3177,6 +3468,58 @@ components:
       - message
       title: HostsModifyResponse
       description: Response with hosts modification result.
+    InitPersistenceRequest:
+      properties:
+        device_ip:
+          type: string
+          title: Device Ip
+          description: Device IP address
+        device_name:
+          type: string
+          maxLength: 100
+          title: Device Name
+          description: Device name from GET :8090/info <name>
+        account_uuid:
+          type: string
+          pattern: ^\d{1,10}$
+          title: Account Uuid
+          description: margeAccountUUID (7-digit numeric, from account pairing)
+      type: object
+      required:
+      - device_ip
+      - device_name
+      - account_uuid
+      title: InitPersistenceRequest
+      description: Request to initialize persistence files on a factory-reset device.
+    InitPersistenceResponse:
+      properties:
+        success:
+          type: boolean
+          title: Success
+        created_files:
+          items:
+            type: string
+          type: array
+          title: Created Files
+        skipped_files:
+          items:
+            type: string
+          type: array
+          title: Skipped Files
+        message:
+          type: string
+          title: Message
+          default: ''
+        error:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error
+      type: object
+      required:
+      - success
+      title: InitPersistenceResponse
+      description: Response from persistence initialization.
     ListBackupsRequest:
       properties:
         device_ip:
@@ -3207,6 +3550,43 @@ components:
       - success
       title: ListBackupsResponse
       description: Response with backup list.
+    LogDownloadRequest:
+      properties:
+        frontend_logs:
+          items:
+            $ref: '#/components/schemas/FrontendLogEntry'
+          type: array
+          title: Frontend Logs
+          default: []
+      type: object
+      title: LogDownloadRequest
+      description: Optional body for POST /api/logs/backend with frontend logs.
+    LogLevelRequest:
+      properties:
+        level:
+          type: string
+          enum:
+          - DEBUG
+          - INFO
+          - WARNING
+          - ERROR
+          - CRITICAL
+          title: Level
+      type: object
+      required:
+      - level
+      title: LogLevelRequest
+      description: Request to change the log level at runtime.
+    LogLevelResponse:
+      properties:
+        level:
+          type: string
+          title: Level
+      type: object
+      required:
+      - level
+      title: LogLevelResponse
+      description: Current log level.
     ManualIPsResponse:
       properties:
         ips:
@@ -3247,7 +3627,7 @@ components:
       required:
       - device_ip
       title: PortCheckRequest
-      description: Request to check SSH/Telnet ports.
+      description: Request to check SSH port.
     PortCheckResponse:
       properties:
         success:
@@ -3514,49 +3894,6 @@ components:
       - msg
       - type
       title: ValidationError
-    AccountPairingRequest:
-      properties:
-        device_ip:
-          type: string
-          title: Device Ip
-          description: Device IP address
-        device_id:
-          type: string
-          title: Device Id
-          description: Device ID (MAC address)
-      type: object
-      required:
-      - device_ip
-      - device_id
-      title: AccountPairingRequest
-      description: Request to ensure device has a margeAccountUUID.
-    AccountPairingResponse:
-      properties:
-        success:
-          type: boolean
-          title: Success
-        had_uuid:
-          type: boolean
-          title: Had Uuid
-          default: false
-        uuid:
-          type: string
-          title: Uuid
-          default: ''
-        message:
-          type: string
-          title: Message
-          default: ''
-        error:
-          anyOf:
-          - type: string
-          - type: 'null'
-          title: Error
-      type: object
-      required:
-      - success
-      title: AccountPairingResponse
-      description: Response from account pairing.
     VerifyRedirectRequest:
       properties:
         device_ip:
@@ -3604,163 +3941,6 @@ components:
       - domain
       - message
       title: VerifyRedirectResponse
-    DiagnosticsRequest:
-      properties:
-        frontend_logs:
-          type: array
-          items:
-            type: object
-          title: Frontend Logs
-          default: []
-        description:
-          type: string
-          title: Description
-          default: ''
-        browser_info:
-          type: string
-          title: Browser Info
-          default: ''
-        current_route:
-          type: string
-          title: Current Route
-          default: ''
-        click_timestamp:
-          type: number
-          title: Click Timestamp
-          default: 0.0
-      type: object
-      title: DiagnosticsRequest
-    AuditEntryRequest:
-      properties:
-        device_id:
-          type: string
-          title: Device Id
-        category:
-          type: string
-          title: Category
-        event:
-          type: string
-          title: Event
-        step:
-          type: integer
-          title: Step
-          minimum: 0
-          maximum: 7
-        detail:
-          type: string
-          title: Detail
-          maxLength: 10000
-        timestamp:
-          type: string
-          title: Timestamp
-      type: object
-      required:
-      - device_id
-      - category
-      - event
-      title: AuditEntryRequest
-    AuditEntryResponse:
-      properties:
-        success:
-          type: boolean
-          title: Success
-        id:
-          type: integer
-          title: Id
-      type: object
-      required:
-      - success
-      - id
-      title: AuditEntryResponse
-    AuditBatchRequest:
-      properties:
-        entries:
-          type: array
-          items:
-            $ref: '#/components/schemas/AuditEntryRequest'
-          title: Entries
-          minItems: 1
-          maxItems: 200
-      type: object
-      required:
-      - entries
-      title: AuditBatchRequest
-    AuditBatchResponse:
-      properties:
-        success:
-          type: boolean
-          title: Success
-        count:
-          type: integer
-          title: Count
-      type: object
-      required:
-      - success
-      - count
-      title: AuditBatchResponse
-    ConfigSnapshotRequest:
-      properties:
-        device_id:
-          type: string
-          title: Device Id
-        file_path:
-          type: string
-          title: File Path
-        content:
-          type: string
-          title: Content
-          maxLength: 50000
-        trigger:
-          type: string
-          title: Trigger
-        timestamp:
-          type: string
-          title: Timestamp
-      type: object
-      required:
-      - device_id
-      - file_path
-      - content
-      title: ConfigSnapshotRequest
-    ConfigSnapshotResponse:
-      properties:
-        success:
-          type: boolean
-          title: Success
-        id:
-          type: integer
-          title: Id
-      type: object
-      required:
-      - success
-      - id
-      title: ConfigSnapshotResponse
-    FrontendLogEntry:
-      properties:
-        timestamp:
-          type: string
-          title: Timestamp
-          default: ''
-        level:
-          type: string
-          title: Level
-          default: ''
-        message:
-          type: string
-          title: Message
-          default: ''
-      type: object
-      title: FrontendLogEntry
-    LogDownloadRequest:
-      properties:
-        frontend_logs:
-          type: array
-          items:
-            $ref: '#/components/schemas/FrontendLogEntry'
-          title: Frontend Logs
-          default: []
-      type: object
-      title: LogDownloadRequest
       description: Response with domain redirect verification result.
     WizardCompleteRequest:
       properties:

--- a/apps/backend/src/opencloudtouch/setup/api_models.py
+++ b/apps/backend/src/opencloudtouch/setup/api_models.py
@@ -308,6 +308,29 @@ class AccountPairingResponse(BaseModel):
     )
     uuid: str = Field(default="", description="The current or newly set UUID")
     message: str = ""
+
+
+class InitPersistenceRequest(BaseModel):
+    """Request to initialize persistence files on a factory-reset device."""
+
+    device_ip: str = Field(..., description="Device IP address")
+    device_name: str = Field(
+        max_length=100,
+        description="Device name from GET :8090/info <name>",
+    )
+    account_uuid: str = Field(
+        pattern=r"^\d{1,10}$",
+        description="margeAccountUUID (7-digit numeric, from account pairing)",
+    )
+
+
+class InitPersistenceResponse(BaseModel):
+    """Response from persistence initialization."""
+
+    success: bool
+    created_files: list[str] = Field(default_factory=list)
+    skipped_files: list[str] = Field(default_factory=list)
+    message: str = ""
     error: Optional[str] = None
 
 

--- a/apps/backend/src/opencloudtouch/setup/api_models.py
+++ b/apps/backend/src/opencloudtouch/setup/api_models.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field, field_validator
 
 # Hostname: letters, digits, hyphens, dots — NO shell metacharacters
 _HOSTNAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9.-]{0,253}[a-zA-Z0-9])?$")
+_DEVICE_IP_DESC = "Device IP address"
 
 
 def _validate_ip_field(v: str) -> str:
@@ -43,7 +44,7 @@ class EnablePermanentSSHRequest(BaseModel):
     """Request to enable permanent SSH access on device."""
 
     device_id: str = Field(..., description="Device ID")
-    ip: str = Field(..., description="Device IP address")
+    ip: str = Field(..., description=_DEVICE_IP_DESC)
     make_permanent: bool = Field(
         default=True, description="Copy remote_services to /mnt/nv/ for persistence"
     )
@@ -295,7 +296,7 @@ class DetectStrategyResponse(BaseModel):
 class AccountPairingRequest(BaseModel):
     """Request to ensure device has a margeAccountUUID."""
 
-    device_ip: str = Field(..., description="Device IP address")
+    device_ip: str = Field(..., description=_DEVICE_IP_DESC)
     device_id: str = Field(..., description="Device ID (MAC address)")
 
 
@@ -313,7 +314,7 @@ class AccountPairingResponse(BaseModel):
 class InitPersistenceRequest(BaseModel):
     """Request to initialize persistence files on a factory-reset device."""
 
-    device_ip: str = Field(..., description="Device IP address")
+    device_ip: str = Field(..., description=_DEVICE_IP_DESC)
     device_name: str = Field(
         max_length=100,
         description="Device name from GET :8090/info <name>",

--- a/apps/backend/src/opencloudtouch/setup/persistence_service.py
+++ b/apps/backend/src/opencloudtouch/setup/persistence_service.py
@@ -91,7 +91,7 @@ async def _write_file_atomic(ssh: SoundTouchSSHClient, path: str, content: str) 
     """Write content to device atomically via base64 piping."""
     b64 = base64.b64encode(content.encode()).decode()
     write_cmd = (
-        f"echo '{b64}' | base64 -d > /tmp/persist.new && " f"mv /tmp/persist.new {path}"
+        f"echo '{b64}' | base64 -d > /tmp/persist.new && mv /tmp/persist.new {path}"
     )
     result = await ssh.execute(write_cmd)
     if not result.success:

--- a/apps/backend/src/opencloudtouch/setup/persistence_service.py
+++ b/apps/backend/src/opencloudtouch/setup/persistence_service.py
@@ -1,0 +1,170 @@
+"""Persistence initialization service for SoundTouch devices.
+
+Factory-reset devices lack the BoseApp-Persistence files that the
+firmware requires for proper preset playback and source initialization.
+Without these files the device never fully initialises its playback
+state, causing INVALID_SOURCE on preset recall (GitHub Issue #167).
+
+This service creates the minimal persistence files needed:
+- SystemConfigurationDB.xml  (account UUID, device name, acctMode)
+- Sources.xml                (available music sources)
+
+Discovery credit: @Zimbo88 (GitHub Issue #167 comment, 2026-05-12).
+"""
+
+import base64
+import logging
+from dataclasses import dataclass
+from typing import Optional
+from xml.sax.saxutils import escape as xml_escape
+
+from opencloudtouch.setup.ssh_client import SoundTouchSSHClient
+
+logger = logging.getLogger(__name__)
+
+_PERSISTENCE_DIR = "/mnt/nv/BoseApp-Persistence/1"
+
+
+@dataclass
+class PersistenceInitResult:
+    """Result of persistence initialization."""
+
+    success: bool
+    created_files: list[str]
+    skipped_files: list[str]
+    message: str = ""
+    error: Optional[str] = None
+
+
+def build_system_config_xml(
+    device_name: str,
+    account_uuid: str,
+) -> str:
+    """Build minimal SystemConfigurationDB.xml.
+
+    Args:
+        device_name: Human-readable device name (from /info)
+        account_uuid: margeAccountUUID (7-digit, from account pairing)
+    """
+    return (
+        '<?xml version="1.0" encoding="UTF-8" ?>\n'
+        "<SystemConfiguration>\n"
+        "    <Password />\n"
+        f"    <DeviceName>{xml_escape(device_name)}</DeviceName>\n"
+        "    <AccountAssociatedEMail />\n"
+        f"    <AccountUUID>{xml_escape(account_uuid)}</AccountUUID>\n"
+        "    <Locale />\n"
+        "    <acctMode>global</acctMode>\n"
+        "    <isMultiDeviceAccount>true</isMultiDeviceAccount>\n"
+        "    <margeAuthServerToken />\n"
+        '    <powerSavingSettings powersaving_en="true" />\n'
+        "</SystemConfiguration>\n"
+    )
+
+
+_SOURCES_XML = """\
+<?xml version="1.0" encoding="UTF-8" ?>
+<sources>
+    <source displayName="AUX IN" secret="" secretType="">
+        <sourceKey type="AUX" account="AUX" />
+    </source>
+    <source displayName="LOCAL_INTERNET_RADIO" secret="" secretType="token">
+        <sourceKey type="LOCAL_INTERNET_RADIO" account="" />
+    </source>
+    <source displayName="RADIO_BROWSER" secret="" secretType="token">
+        <sourceKey type="RADIO_BROWSER" account="" />
+    </source>
+    <source displayName="TUNEIN" secret="" secretType="token">
+        <sourceKey type="TUNEIN" account="" />
+    </source>
+</sources>
+"""
+
+
+async def _file_exists(ssh: SoundTouchSSHClient, path: str) -> bool:
+    """Check if a file exists on the device."""
+    result = await ssh.execute(f"test -f {path} && echo 'exists' || echo 'missing'")
+    return "exists" in (result.output or "")
+
+
+async def _write_file_atomic(ssh: SoundTouchSSHClient, path: str, content: str) -> None:
+    """Write content to device atomically via base64 piping."""
+    b64 = base64.b64encode(content.encode()).decode()
+    write_cmd = (
+        f"echo '{b64}' | base64 -d > /tmp/persist.new && " f"mv /tmp/persist.new {path}"
+    )
+    result = await ssh.execute(write_cmd)
+    if not result.success:
+        raise RuntimeError(f"Failed to write {path}: {result.error or result.output}")
+
+
+async def ensure_persistence_files(
+    ssh: SoundTouchSSHClient,
+    device_name: str,
+    account_uuid: str,
+) -> PersistenceInitResult:
+    """Ensure minimal persistence files exist on the device.
+
+    Only creates files that are missing — never overwrites existing ones.
+    This preserves user data on devices that already have valid state.
+
+    Must be called AFTER:
+    - Config modification (SDK URLs rewritten)
+    - Hosts modification (domains redirected)
+    - Account pairing (margeAccountUUID set)
+    - Filesystem remounted rw
+
+    Args:
+        ssh: Connected SSH client
+        device_name: Device name (from GET :8090/info <name>)
+        account_uuid: margeAccountUUID (from account pairing)
+
+    Returns:
+        PersistenceInitResult
+    """
+    created: list[str] = []
+    skipped: list[str] = []
+
+    files_to_ensure = [
+        (
+            "SystemConfigurationDB.xml",
+            lambda: build_system_config_xml(device_name, account_uuid),
+        ),
+        ("Sources.xml", lambda: _SOURCES_XML),
+    ]
+
+    try:
+        # Ensure directory exists
+        await ssh.execute(f"mkdir -p {_PERSISTENCE_DIR}")
+
+        for filename, content_fn in files_to_ensure:
+            path = f"{_PERSISTENCE_DIR}/{filename}"
+            if await _file_exists(ssh, path):
+                logger.info("%s already exists — skipping", filename)
+                skipped.append(path)
+            else:
+                logger.info("Creating %s", filename)
+                await _write_file_atomic(ssh, path, content_fn())
+                created.append(path)
+
+        msg_parts = []
+        if created:
+            msg_parts.append(f"Created: {', '.join(created)}")
+        if skipped:
+            msg_parts.append(f"Skipped (already exist): {', '.join(skipped)}")
+
+        return PersistenceInitResult(
+            success=True,
+            created_files=created,
+            skipped_files=skipped,
+            message=" | ".join(msg_parts) or "No action needed",
+        )
+
+    except Exception as e:
+        logger.error("Persistence initialization failed: %s", e)
+        return PersistenceInitResult(
+            success=False,
+            created_files=created,
+            skipped_files=skipped,
+            error=str(e),
+        )

--- a/apps/backend/src/opencloudtouch/setup/persistence_service.py
+++ b/apps/backend/src/opencloudtouch/setup/persistence_service.py
@@ -161,7 +161,7 @@ async def ensure_persistence_files(
         )
 
     except Exception as e:
-        logger.error("Persistence initialization failed: %s", e)
+        logger.exception("Persistence initialization failed")
         return PersistenceInitResult(
             success=False,
             created_files=created,

--- a/apps/backend/src/opencloudtouch/setup/wizard_routes.py
+++ b/apps/backend/src/opencloudtouch/setup/wizard_routes.py
@@ -23,6 +23,8 @@ from opencloudtouch.setup.api_models import (
     DetectStrategyResponse,
     EnsureAccountRequest,
     EnsureAccountResponse,
+    InitPersistenceRequest,
+    InitPersistenceResponse,
     HostsModifyRequest,
     HostsModifyResponse,
     ListBackupsRequest,
@@ -38,7 +40,7 @@ from opencloudtouch.setup.api_models import (
     AccountPairingRequest,
     AccountPairingResponse,
 )
-from opencloudtouch.setup.wizard_helpers import check_port_443
+from opencloudtouch.setup.wizard_helpers import check_port_443, ssh_operation
 from opencloudtouch.setup.wizard_service import WizardService
 
 logger = logging.getLogger(__name__)
@@ -333,6 +335,53 @@ async def wizard_ensure_account(request: EnsureAccountRequest):
         success=True,
         had_uuid=result.had_uuid,
         uuid=result.uuid,
+        message=result.message,
+    )
+
+
+@wizard_router.post("/wizard/init-persistence", response_model=InitPersistenceResponse)
+async def wizard_init_persistence(request: InitPersistenceRequest):
+    """Initialize persistence files on factory-reset devices (Wizard Step — after account pairing).
+
+    Factory-reset devices lack SystemConfigurationDB.xml and Sources.xml.
+    Without them, the firmware never fully initialises playback state,
+    causing INVALID_SOURCE on preset recall (GitHub Issue #167).
+
+    Only creates files that are missing — never overwrites existing ones.
+    Safe to call multiple times.
+    """
+    from opencloudtouch.setup.persistence_service import ensure_persistence_files
+
+    logger.info(
+        "Initializing persistence files on %s (name=%s, uuid=%s)",
+        request.device_ip,
+        request.device_name,
+        request.account_uuid,
+    )
+
+    async with ssh_operation(request.device_ip, "init-persistence") as ssh:
+        # Remount rw for file creation
+        await ssh.execute("mount -o remount,rw /")
+        try:
+            result = await ensure_persistence_files(
+                ssh=ssh,
+                device_name=request.device_name,
+                account_uuid=request.account_uuid,
+            )
+        finally:
+            await ssh.execute("sync")
+            await ssh.execute("mount -o remount,ro /")
+
+    if not result.success:
+        return InitPersistenceResponse(
+            success=False,
+            message=result.error or "Persistence initialization failed",
+        )
+
+    return InitPersistenceResponse(
+        success=True,
+        created_files=result.created_files,
+        skipped_files=result.skipped_files,
         message=result.message,
     )
 

--- a/apps/backend/tests/unit/setup/test_persistence_service.py
+++ b/apps/backend/tests/unit/setup/test_persistence_service.py
@@ -1,0 +1,241 @@
+"""Tests for persistence_service — factory-reset device initialization."""
+
+import base64
+
+import pytest
+from unittest.mock import AsyncMock
+
+from opencloudtouch.setup.persistence_service import (
+    build_system_config_xml,
+    ensure_persistence_files,
+    _PERSISTENCE_DIR,
+    _SOURCES_XML,
+)
+from opencloudtouch.setup.ssh_client import CommandResult
+
+# —— XML Generation ————————————————————————————————————
+
+
+class TestBuildSystemConfigXml:
+    """Tests for SystemConfigurationDB.xml generation."""
+
+    def test_contains_device_name(self):
+        xml = build_system_config_xml("Kitchen Speaker", "1234567")
+        assert "<DeviceName>Kitchen Speaker</DeviceName>" in xml
+
+    def test_contains_account_uuid(self):
+        xml = build_system_config_xml("Test", "8866380")
+        assert "<AccountUUID>8866380</AccountUUID>" in xml
+
+    def test_has_xml_declaration(self):
+        xml = build_system_config_xml("Test", "1234567")
+        assert xml.startswith('<?xml version="1.0"')
+
+    def test_has_closing_tag(self):
+        xml = build_system_config_xml("Test", "1234567")
+        assert "</SystemConfiguration>" in xml
+
+    def test_global_acct_mode(self):
+        xml = build_system_config_xml("Test", "1234567")
+        assert "<acctMode>global</acctMode>" in xml
+
+    def test_multi_device_account_true(self):
+        xml = build_system_config_xml("Test", "1234567")
+        assert "<isMultiDeviceAccount>true</isMultiDeviceAccount>" in xml
+
+
+class TestSourcesXml:
+    """Tests for the static Sources.xml template."""
+
+    def test_contains_local_internet_radio(self):
+        assert 'type="LOCAL_INTERNET_RADIO"' in _SOURCES_XML
+
+    def test_contains_tunein(self):
+        assert 'type="TUNEIN"' in _SOURCES_XML
+
+    def test_contains_radio_browser(self):
+        assert 'type="RADIO_BROWSER"' in _SOURCES_XML
+
+    def test_contains_aux(self):
+        assert 'type="AUX"' in _SOURCES_XML
+
+    def test_has_xml_declaration(self):
+        assert _SOURCES_XML.startswith('<?xml version="1.0"')
+
+
+# —— Helpers ———————————————————————————————————————————
+
+
+def _mock_ssh(file_exists_map: dict[str, bool] | None = None) -> AsyncMock:
+    """Create a mock SSH client with configurable file existence."""
+    ssh = AsyncMock()
+    exists = file_exists_map or {}
+
+    async def fake_execute(cmd: str) -> CommandResult:
+        # mkdir -p
+        if cmd.startswith("mkdir"):
+            return CommandResult(success=True, output="", exit_code=0)
+        # file existence check
+        if "test -f" in cmd:
+            path = cmd.split("test -f ")[1].split(" &&")[0]
+            found = exists.get(path, False)
+            return CommandResult(
+                success=True,
+                output="exists" if found else "missing",
+                exit_code=0,
+            )
+        # write (base64 pipe)
+        if "base64 -d" in cmd:
+            return CommandResult(success=True, output="", exit_code=0)
+        # fallback
+        return CommandResult(success=True, output="", exit_code=0)
+
+    ssh.execute = AsyncMock(side_effect=fake_execute)
+    return ssh
+
+
+# —— ensure_persistence_files ——————————————————————————
+
+
+class TestEnsurePersistenceFiles:
+    """Tests for the main persistence initialization function."""
+
+    @pytest.mark.asyncio
+    async def test_creates_both_files_when_missing(self):
+        ssh = _mock_ssh({})  # no files exist
+        result = await ensure_persistence_files(ssh, "SoundTouch 20", "8866380")
+
+        assert result.success is True
+        assert len(result.created_files) == 2
+        assert f"{_PERSISTENCE_DIR}/SystemConfigurationDB.xml" in result.created_files
+        assert f"{_PERSISTENCE_DIR}/Sources.xml" in result.created_files
+        assert result.skipped_files == []
+
+    @pytest.mark.asyncio
+    async def test_skips_existing_files(self):
+        ssh = _mock_ssh(
+            {
+                f"{_PERSISTENCE_DIR}/SystemConfigurationDB.xml": True,
+                f"{_PERSISTENCE_DIR}/Sources.xml": True,
+            }
+        )
+        result = await ensure_persistence_files(ssh, "SoundTouch 20", "8866380")
+
+        assert result.success is True
+        assert result.created_files == []
+        assert len(result.skipped_files) == 2
+
+    @pytest.mark.asyncio
+    async def test_creates_only_missing_sysconfig(self):
+        ssh = _mock_ssh(
+            {
+                f"{_PERSISTENCE_DIR}/SystemConfigurationDB.xml": False,
+                f"{_PERSISTENCE_DIR}/Sources.xml": True,
+            }
+        )
+        result = await ensure_persistence_files(ssh, "Test", "1234567")
+
+        assert result.success is True
+        assert len(result.created_files) == 1
+        assert f"{_PERSISTENCE_DIR}/SystemConfigurationDB.xml" in result.created_files
+        assert f"{_PERSISTENCE_DIR}/Sources.xml" in result.skipped_files
+
+    @pytest.mark.asyncio
+    async def test_creates_only_missing_sources(self):
+        ssh = _mock_ssh(
+            {
+                f"{_PERSISTENCE_DIR}/SystemConfigurationDB.xml": True,
+                f"{_PERSISTENCE_DIR}/Sources.xml": False,
+            }
+        )
+        result = await ensure_persistence_files(ssh, "Test", "1234567")
+
+        assert result.success is True
+        assert len(result.created_files) == 1
+        assert f"{_PERSISTENCE_DIR}/Sources.xml" in result.created_files
+        assert f"{_PERSISTENCE_DIR}/SystemConfigurationDB.xml" in result.skipped_files
+
+    @pytest.mark.asyncio
+    async def test_ensures_directory_created(self):
+        ssh = _mock_ssh({})
+        await ensure_persistence_files(ssh, "Test", "1234567")
+
+        # First call should be mkdir -p
+        first_call = ssh.execute.call_args_list[0]
+        assert f"mkdir -p {_PERSISTENCE_DIR}" in first_call.args[0]
+
+    @pytest.mark.asyncio
+    async def test_returns_error_on_write_failure(self):
+        ssh = AsyncMock()
+        call_count = 0
+
+        async def failing_execute(cmd: str) -> CommandResult:
+            nonlocal call_count
+            call_count += 1
+            if cmd.startswith("mkdir"):
+                return CommandResult(success=True, output="", exit_code=0)
+            if "test -f" in cmd:
+                return CommandResult(success=True, output="missing", exit_code=0)
+            if "base64 -d" in cmd:
+                return CommandResult(
+                    success=False, output="", exit_code=1, error="disk full"
+                )
+            return CommandResult(success=True, output="", exit_code=0)
+
+        ssh.execute = AsyncMock(side_effect=failing_execute)
+        result = await ensure_persistence_files(ssh, "Test", "1234567")
+
+        assert result.success is False
+        assert result.error is not None
+        assert "disk full" in result.error or "Failed to write" in result.error
+
+    @pytest.mark.asyncio
+    async def test_written_sysconfig_contains_uuid(self):
+        """Verify the actual XML content written contains the UUID."""
+        ssh = _mock_ssh({})
+        written_content = []
+
+        original_execute = ssh.execute.side_effect
+
+        async def capture_execute(cmd: str) -> CommandResult:
+            result = await original_execute(cmd)
+            if "base64 -d" in cmd:
+                written_content.append(cmd)
+            return result
+
+        ssh.execute = AsyncMock(side_effect=capture_execute)
+        await ensure_persistence_files(ssh, "Kitchen", "5551234")
+
+        assert len(written_content) >= 1
+        # Decode base64 payload from the first write command and verify UUID
+        first_write = written_content[0]
+        b64_payload = first_write.split("echo '")[1].split("'")[0]
+        decoded = base64.b64decode(b64_payload).decode()
+        assert "5551234" in decoded
+        assert "Kitchen" in decoded
+
+
+class TestXmlEscaping:
+    """Tests for XML special character handling in device names."""
+
+    def test_escapes_angle_brackets(self):
+        xml = build_system_config_xml("Bose <Living Room>", "1234567")
+        assert "&lt;Living Room&gt;" in xml
+        assert "<Living Room>" not in xml
+
+    def test_escapes_ampersand(self):
+        xml = build_system_config_xml("Kitchen & Bath", "1234567")
+        assert "Kitchen &amp; Bath" in xml
+
+    def test_escapes_quotes_in_name(self):
+        xml = build_system_config_xml('My "Speaker"', "1234567")
+        assert "</DeviceName>" in xml
+        assert "</SystemConfiguration>" in xml
+
+    def test_result_is_parseable_xml(self):
+        from defusedxml import ElementTree as ET
+
+        xml = build_system_config_xml("Böse <Lautsprecher> & Mehr", "9876543")
+        root = ET.fromstring(xml)
+        assert root.find("DeviceName").text == "Böse <Lautsprecher> & Mehr"
+        assert root.find("AccountUUID").text == "9876543"

--- a/apps/frontend/src/api/generated/schema.ts
+++ b/apps/frontend/src/api/generated/schema.ts
@@ -1031,8 +1031,7 @@ export interface paths {
      *
      *     Args:
      *         device_id: Device MAC address (e.g., "689E194F7D2F")
-     *         preset_repo: Preset repository dependency
-     *         recents_repo: Recents repository dependency
+     *         marge: Marge service dependency
      *
      *     Returns:
      *         XML Response with <boseAccount> structure
@@ -1059,7 +1058,7 @@ export interface paths {
      *
      *     Args:
      *         device_id: Device MAC address
-     *         preset_repo: Preset repository dependency
+     *         marge: Marge service dependency
      *
      *     Returns:
      *         XML Response with <presets> structure
@@ -1086,7 +1085,7 @@ export interface paths {
      *
      *     Args:
      *         device_id: Device MAC address
-     *         recents_repo: Recents repository dependency
+     *         marge: Marge service dependency
      *
      *     Returns:
      *         XML Response with <recents> structure
@@ -1293,11 +1292,12 @@ export interface paths {
      * @description Get full account sync via streaming endpoint.
      *
      *     This is the streaming.bose.com version of the account sync endpoint.
-     *     Returns complete account with all devices, presets, recents, and sources.
+     *     Resolves the device_id from the account_id (margeAccountUUID) stored
+     *     during device discovery, then returns that device's presets.
      *
      *     Args:
      *         account_id: Account ID (e.g., "3784726")
-     *         preset_repo: Preset repository dependency
+     *         marge: Marge service dependency
      *
      *     Returns:
      *         XML Response with <account> structure
@@ -1334,6 +1334,131 @@ export interface paths {
      *         200 OK
      */
     post: operations["scmudc_reporting_v1_scmudc__device_id__post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/streaming/stats/usage": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Streaming Stats Usage
+     * @description Accept device usage statistics (stub).
+     *
+     *     Without this endpoint, the device retries repeatedly after
+     *     statsServerUrl is redirected to OCT.
+     *
+     *     Returns:
+     *         200 OK
+     */
+    post: operations["streaming_stats_usage_streaming_stats_usage_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/streaming/device/{device_id}/streaming_token": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Streaming Token
+     * @description Return a dummy streaming token for device authentication.
+     *
+     *     SoundTouch firmware 27.x requests this token before playing a preset.
+     *     If the request fails, the device aborts playback with INVALID_SOURCE.
+     *     The token value is not validated — any non-empty response suffices.
+     *
+     *     Args:
+     *         device_id: Device MAC address
+     *
+     *     Returns:
+     *         JSON with a dummy access token
+     */
+    get: operations["streaming_token_streaming_device__device_id__streaming_token_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/blacklist/{device_id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Blacklist Check
+     * @description Content blacklist check — always returns empty (nothing blacklisted).
+     *
+     *     The device checks this before playing content. If the endpoint is
+     *     unreachable, some firmware versions refuse playback.
+     *
+     *     Args:
+     *         device_id: Device MAC address
+     *
+     *     Returns:
+     *         JSON with empty blacklist
+     */
+    get: operations["blacklist_check_v1_blacklist__device_id__get"];
+    put?: never;
+    /**
+     * Blacklist Check
+     * @description Content blacklist check — always returns empty (nothing blacklisted).
+     *
+     *     The device checks this before playing content. If the endpoint is
+     *     unreachable, some firmware versions refuse playback.
+     *
+     *     Args:
+     *         device_id: Device MAC address
+     *
+     *     Returns:
+     *         JSON with empty blacklist
+     */
+    post: operations["blacklist_check_v1_blacklist__device_id__post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/setMargeAccount": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Set Marge Account
+     * @description Pair device with a Bose Cloud account (stub).
+     *
+     *     The SoundTouch app calls this to associate a device with an account.
+     *     OCT doesn't use real cloud accounts, but the device expects a 200 OK.
+     *     The actual margeAccountUUID is set via Telnet or device-side API.
+     *
+     *     Returns:
+     *         200 OK with status XML
+     */
+    post: operations["set_marge_account_setMargeAccount_post"];
     delete?: never;
     options?: never;
     head?: never;
@@ -1457,7 +1582,7 @@ export interface paths {
     put?: never;
     /**
      * Check Connectivity
-     * @description Check if device is ready for setup (SSH/Telnet available).
+     * @description Check if device is ready for setup (SSH available).
      *
      *     This should be called after user inserts USB stick and reboots device.
      */
@@ -1623,7 +1748,7 @@ export interface paths {
     put?: never;
     /**
      * Wizard Check Ports
-     * @description Check if SSH/Telnet ports accessible (Wizard Step 3).
+     * @description Check if SSH port is accessible (Wizard Step 3).
      */
     post: operations["wizard_check_ports_api_setup_wizard_check_ports_post"];
     delete?: never;
@@ -1764,12 +1889,84 @@ export interface paths {
     /**
      * Wizard Reboot Device
      * @description Reboot SoundTouch device via SSH (Wizard Step 7).
-     *
-     *     Sends the `reboot` command via SSH. The device drops the SSH connection
-     *     immediately after receiving the command — this is expected and not an error.
-     *     Frontend should wait ~60s before attempting verify-redirect tests.
      */
     post: operations["wizard_reboot_device_api_setup_wizard_reboot_device_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/setup/wizard/account-pairing": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Wizard Account Pairing
+     * @description Ensure device has a margeAccountUUID (Wizard Step - Account Pairing).
+     *
+     *     Checks if the device already has a UUID. If not, generates one and
+     *     sets it via Telnet. Persists the UUID in the device repository for
+     *     streaming endpoint resolution.
+     */
+    post: operations["wizard_account_pairing_api_setup_wizard_account_pairing_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/setup/wizard/ensure-account": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Wizard Ensure Account
+     * @description Ensure device has a margeAccountUUID (Wizard Step � after config/hosts).
+     *
+     *     Devices without a margeAccountUUID cannot play presets (INVALID_SOURCE).
+     *     This endpoint checks GET :8090/info and sets a UUID via Telnet if missing.
+     *
+     *     Safe to call multiple times � no-op if UUID already present.
+     */
+    post: operations["wizard_ensure_account_api_setup_wizard_ensure_account_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/setup/wizard/init-persistence": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Wizard Init Persistence
+     * @description Initialize persistence files on factory-reset devices (Wizard Step — after account pairing).
+     *
+     *     Factory-reset devices lack SystemConfigurationDB.xml and Sources.xml.
+     *     Without them, the firmware never fully initialises playback state,
+     *     causing INVALID_SOURCE on preset recall (GitHub Issue #167).
+     *
+     *     Only creates files that are missing — never overwrites existing ones.
+     *     Safe to call multiple times.
+     */
+    post: operations["wizard_init_persistence_api_setup_wizard_init_persistence_post"];
     delete?: never;
     options?: never;
     head?: never;
@@ -1788,9 +1985,6 @@ export interface paths {
     /**
      * Wizard Complete
      * @description Mark wizard setup as complete for a device.
-     *
-     *     Updates the device's setup_status to 'configured' in the database.
-     *     Called by the frontend when the user finishes the wizard.
      */
     post: operations["wizard_complete_api_setup_wizard_complete_post"];
     delete?: never;
@@ -1811,9 +2005,6 @@ export interface paths {
     /**
      * Wizard Verify Redirect
      * @description Verify a domain is redirected to OCT on the device (Wizard Step 7).
-     *
-     *     SSH into the device, run ping against the domain, and check whether
-     *     the resolved IP matches the OCT server's IP.
      */
     post: operations["wizard_verify_redirect_api_setup_wizard_verify_redirect_post"];
     delete?: never;
@@ -1833,8 +2024,8 @@ export interface paths {
      * Firmware Index
      * @description Return firmware INDEX.XML for SoundTouch devices.
      *
-     *     The device checks this endpoint at boot and periodically
-     *     to determine if a firmware update is available.
+     *     Serves the original Bose worldwide.bose.com index so devices recognise
+     *     their current firmware as up-to-date and don't attempt downloads.
      */
     get: operations["firmware_index_updates_soundtouch_get"];
     put?: never;
@@ -1853,18 +2044,10 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * Firmware Download
-     * @description Redirect firmware download to device.
-     *
-     *     Firmware files are large (100+ MB). Instead of hosting them,
-     *     we return a 404 — OCT intentionally does NOT serve firmware
-     *     updates to prevent devices from updating to versions that
-     *     might break OCT compatibility.
-     *
-     *     In the future, this could proxy to archive.org for
-     *     specific firmware versions needed for downgrading.
+     * Firmware Download Legacy
+     * @description Block legacy firmware download path.
      */
-    get: operations["firmware_download_ced_eup_downloads_rel__filename__get"];
+    get: operations["firmware_download_legacy_ced_eup_downloads_rel__filename__get"];
     put?: never;
     post?: never;
     delete?: never;
@@ -1882,8 +2065,11 @@ export interface paths {
     };
     /**
      * Firmware Download
-     * @description Block real Bose firmware download path (Stockholm devices).
-     *     Returns 404 to prevent unintended firmware updates.
+     * @description Block real Bose firmware download path.
+     *
+     *     The real index XML references https://downloads.bose.com/ced/soundtouch/...
+     *     but since swUpdateUrl points to OCT, the device may try to fetch from here.
+     *     We return 404 to prevent unintended firmware updates.
      */
     get: operations["firmware_download_ced_soundtouch_downloads_stockholm__path__get"];
     put?: never;
@@ -2002,26 +2188,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  "/health": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Health Check
-     * @description Health check endpoint for Docker and monitoring.
-     */
-    get: operations["health_check_health_get"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   "/api/logs/level": {
     parameters: {
       query?: never;
@@ -2048,16 +2214,16 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * Download Backend Log
-     * @description Returns the in-memory backend log as a plain-text file download.
+     * Download backend log buffer (without frontend logs)
+     * @description Returns backend logs only. Use POST to include frontend console logs.
      */
-    get: operations["download_backend_log_api_logs_backend_get"];
+    get: operations["download_backend_logs_get_api_logs_backend_get"];
     put?: never;
     /**
-     * Download Logs with Frontend Console
-     * @description Returns backend + frontend console logs as a plain-text file download.
+     * Download backend + frontend logs
+     * @description Returns backend logs with frontend console logs included.
      */
-    post: operations["download_backend_log_api_logs_backend_post"];
+    post: operations["download_backend_logs_post_api_logs_backend_post"];
     delete?: never;
     options?: never;
     head?: never;
@@ -2074,10 +2240,10 @@ export interface paths {
     get?: never;
     put?: never;
     /**
-     * Submit Bug Report
-     * @description Submit a bug report that creates a GitHub issue with diagnostic data.
+     * Create Bug Report
+     * @description Create a bug report as a GitHub Issue with auto-collected diagnostics.
      */
-    post: operations["submit_bug_report_api_bug_report_post"];
+    post: operations["create_bug_report_api_bug_report_post"];
     delete?: never;
     options?: never;
     head?: never;
@@ -2095,7 +2261,9 @@ export interface paths {
     put?: never;
     /**
      * Download Diagnostics
-     * @description Download a gzipped diagnostic bundle without requiring a GitHub token.
+     * @description Download a gzipped diagnostic bundle — works without GitHub token.
+     *
+     *     The user can drag-drop the .log.gz file into a manually created GitHub issue.
      */
     post: operations["download_diagnostics_api_bug_report_diagnostics_post"];
     delete?: never;
@@ -2155,9 +2323,29 @@ export interface paths {
     put?: never;
     /**
      * Post Config Snapshot
-     * @description Store a config XML snapshot for audit purposes.
+     * @description Store a config XML snapshot.
      */
     post: operations["post_config_snapshot_api_wizard_config_snapshot_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/health": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Health Check
+     * @description Health check endpoint for Docker and monitoring.
+     */
+    get: operations["health_check_health_get"];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -2168,18 +2356,110 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
-    /** LogLevelResponse */
-    LogLevelResponse: {
-      /** Level */
-      level: string;
-    };
-    /** LogLevelRequest */
-    LogLevelRequest: {
+    /**
+     * AccountPairingRequest
+     * @description Request to ensure device has a margeAccountUUID.
+     */
+    AccountPairingRequest: {
       /**
-       * Level
-       * @enum {string}
+       * Device Ip
+       * @description Device IP address
        */
-      level: "DEBUG" | "INFO" | "WARNING" | "ERROR" | "CRITICAL";
+      device_ip: string;
+      /**
+       * Device Id
+       * @description Device ID (MAC address)
+       */
+      device_id: string;
+    };
+    /**
+     * AccountPairingResponse
+     * @description Response from account pairing.
+     */
+    AccountPairingResponse: {
+      /** Success */
+      success: boolean;
+      /**
+       * Had Uuid
+       * @description True if UUID was already present
+       * @default false
+       */
+      had_uuid: boolean;
+      /**
+       * Uuid
+       * @description The current or newly set UUID
+       * @default
+       */
+      uuid: string;
+      /**
+       * Message
+       * @default
+       */
+      message: string;
+    };
+    /**
+     * AuditBatchRequest
+     * @description Batch of audit entries (reduces HTTP roundtrips).
+     */
+    AuditBatchRequest: {
+      /** Entries */
+      entries: components["schemas"]["AuditEntryRequest"][];
+    };
+    /**
+     * AuditBatchResponse
+     * @description Response for batch creation.
+     */
+    AuditBatchResponse: {
+      /** Success */
+      success: boolean;
+      /** Count */
+      count: number;
+    };
+    /**
+     * AuditEntryRequest
+     * @description Single wizard audit log entry from the frontend.
+     */
+    AuditEntryRequest: {
+      /**
+       * Device Id
+       * @description Device MAC/ID
+       */
+      device_id: string;
+      /**
+       * Category
+       * @description Event category: user_action, device_info, api_call, config_change, step_transition, checkbox, dropdown, error
+       */
+      category: string;
+      /**
+       * Event
+       * @description Short event name, e.g. 'button_click:next'
+       */
+      event: string;
+      /**
+       * Step
+       * @description Wizard step number (0=init)
+       */
+      step?: number | null;
+      /**
+       * Detail
+       * @description JSON-encoded extra data (free-form)
+       */
+      detail?: string | null;
+      /**
+       * Timestamp
+       * @description ISO-8601 timestamp from frontend
+       */
+      timestamp?: string | null;
+    };
+    /**
+     * AuditEntryResponse
+     * @description Response for single entry creation.
+     */
+    AuditEntryResponse: {
+      /** Success */
+      success: boolean;
+      /** Id */
+      id: number;
     };
     /**
      * BackupRequest
@@ -2191,9 +2471,8 @@ export interface components {
       /**
        * Device Id
        * @description Device identifier for unique backup filenames
-       * @default null
        */
-      device_id: string | null;
+      device_id?: string | null;
     };
     /**
      * BackupResponse
@@ -2217,26 +2496,6 @@ export interface components {
        */
       total_duration_seconds: number;
     };
-    /** BugReportRequest */
-    BugReportRequest: {
-      description: string;
-      steps_to_reproduce: string;
-      expected_behavior: string;
-      installation_type: string;
-      hardware: string;
-      /** @default [] */
-      soundtouch_devices: string[];
-      /** @default  */
-      other_installation: string;
-      /** @default  */
-      other_hardware: string;
-    };
-    /** BugReportResponse */
-    BugReportResponse: {
-      issue_url?: string;
-      issue_number?: number;
-      message?: string;
-    };
     /** Body_set_mute_api_devices__device_id__mute_put */
     Body_set_mute_api_devices__device_id__mute_put: {
       /** Muted */
@@ -2246,6 +2505,79 @@ export interface components {
     Body_set_volume_api_devices__device_id__volume_put: {
       /** Level */
       level: number;
+    };
+    /** BugReportRequest */
+    BugReportRequest: {
+      /** Description */
+      description: string;
+      /** Steps To Reproduce */
+      steps_to_reproduce: string;
+      /** Expected Behavior */
+      expected_behavior: string;
+      /** Installation Type */
+      installation_type: string;
+      /** Hardware */
+      hardware: string;
+      /**
+       * Soundtouch Devices
+       * @default []
+       */
+      soundtouch_devices: string[];
+      /**
+       * Network Config
+       * @default
+       */
+      network_config: string;
+      /**
+       * Additional Info
+       * @default
+       */
+      additional_info: string;
+      /**
+       * Other Installation
+       * @default
+       */
+      other_installation: string;
+      /**
+       * Other Hardware
+       * @default
+       */
+      other_hardware: string;
+      /**
+       * Other Device
+       * @default
+       */
+      other_device: string;
+      /**
+       * Screenshot Data Url
+       * @default
+       */
+      screenshot_data_url: string;
+      /**
+       * Frontend Logs
+       * @default []
+       */
+      frontend_logs: Record<string, never>[];
+      /**
+       * Browser Info
+       * @default
+       */
+      browser_info: string;
+      /**
+       * Current Route
+       * @default
+       */
+      current_route: string;
+      /**
+       * Click Timestamp
+       * @default 0
+       */
+      click_timestamp: number;
+    };
+    /** BugReportResponse */
+    BugReportResponse: {
+      /** Issue Url */
+      issue_url: string;
     };
     /**
      * ChangeMasterRequest
@@ -2299,6 +2631,41 @@ export interface components {
       new_url: string;
     };
     /**
+     * ConfigSnapshotRequest
+     * @description Request to store a config XML snapshot.
+     */
+    ConfigSnapshotRequest: {
+      /** Device Id */
+      device_id: string;
+      /**
+       * File Path
+       * @description Config file path on device
+       */
+      file_path: string;
+      /**
+       * Content
+       * @description Full XML content
+       */
+      content: string;
+      /**
+       * Trigger
+       * @description What caused the snapshot, e.g. 'before_modify'
+       */
+      trigger?: string | null;
+      /** Timestamp */
+      timestamp?: string | null;
+    };
+    /**
+     * ConfigSnapshotResponse
+     * @description Response for snapshot creation.
+     */
+    ConfigSnapshotResponse: {
+      /** Success */
+      success: boolean;
+      /** Id */
+      id: number;
+    };
+    /**
      * ConnectivityCheckRequest
      * @description Request to check device connectivity.
      */
@@ -2335,6 +2702,37 @@ export interface components {
       message: string;
     };
     /**
+     * DiagnosticsRequest
+     * @description Request body for diagnostics download (no GitHub token needed).
+     */
+    DiagnosticsRequest: {
+      /**
+       * Frontend Logs
+       * @default []
+       */
+      frontend_logs: Record<string, never>[];
+      /**
+       * Description
+       * @default
+       */
+      description: string;
+      /**
+       * Browser Info
+       * @default
+       */
+      browser_info: string;
+      /**
+       * Current Route
+       * @default
+       */
+      current_route: string;
+      /**
+       * Click Timestamp
+       * @default 0
+       */
+      click_timestamp: number;
+    };
+    /**
      * EnablePermanentSSHRequest
      * @description Request to enable permanent SSH access on device.
      */
@@ -2355,6 +2753,27 @@ export interface components {
        * @default true
        */
       make_permanent: boolean;
+    };
+    /**
+     * FrontendLogEntry
+     * @description A single frontend console log entry.
+     */
+    FrontendLogEntry: {
+      /**
+       * Timestamp
+       * @default
+       */
+      timestamp: string;
+      /**
+       * Level
+       * @default
+       */
+      level: string;
+      /**
+       * Message
+       * @default
+       */
+      message: string;
     };
     /** HTTPValidationError */
     HTTPValidationError: {
@@ -2400,6 +2819,46 @@ export interface components {
       diff: string;
     };
     /**
+     * InitPersistenceRequest
+     * @description Request to initialize persistence files on a factory-reset device.
+     */
+    InitPersistenceRequest: {
+      /**
+       * Device Ip
+       * @description Device IP address
+       */
+      device_ip: string;
+      /**
+       * Device Name
+       * @description Device name from GET :8090/info <name>
+       */
+      device_name: string;
+      /**
+       * Account Uuid
+       * @description margeAccountUUID (7-digit numeric, from account pairing)
+       */
+      account_uuid: string;
+    };
+    /**
+     * InitPersistenceResponse
+     * @description Response from persistence initialization.
+     */
+    InitPersistenceResponse: {
+      /** Success */
+      success: boolean;
+      /** Created Files */
+      created_files?: string[];
+      /** Skipped Files */
+      skipped_files?: string[];
+      /**
+       * Message
+       * @default
+       */
+      message: string;
+      /** Error */
+      error?: string | null;
+    };
+    /**
      * ListBackupsRequest
      * @description Request to list backups.
      */
@@ -2418,6 +2877,36 @@ export interface components {
       config_backups?: string[];
       /** Hosts Backups */
       hosts_backups?: string[];
+    };
+    /**
+     * LogDownloadRequest
+     * @description Optional body for POST /api/logs/backend with frontend logs.
+     */
+    LogDownloadRequest: {
+      /**
+       * Frontend Logs
+       * @default []
+       */
+      frontend_logs: components["schemas"]["FrontendLogEntry"][];
+    };
+    /**
+     * LogLevelRequest
+     * @description Request to change the log level at runtime.
+     */
+    LogLevelRequest: {
+      /**
+       * Level
+       * @enum {string}
+       */
+      level: "DEBUG" | "INFO" | "WARNING" | "ERROR" | "CRITICAL";
+    };
+    /**
+     * LogLevelResponse
+     * @description Current log level.
+     */
+    LogLevelResponse: {
+      /** Level */
+      level: string;
     };
     /**
      * ManualIPsResponse
@@ -2440,7 +2929,7 @@ export interface components {
     };
     /**
      * PortCheckRequest
-     * @description Request to check SSH/Telnet ports.
+     * @description Request to check SSH port.
      */
     PortCheckRequest: {
       /** Device Ip */
@@ -2640,7 +3129,10 @@ export interface components {
       /** Expected Ip */
       expected_ip: string;
     };
-    /** VerifyRedirectResponse */
+    /**
+     * VerifyRedirectResponse
+     * @description Response with domain redirect verification result.
+     */
     VerifyRedirectResponse: {
       /** Success */
       success: boolean;
@@ -2663,117 +3155,6 @@ export interface components {
       matches_expected: boolean;
       /** Message */
       message: string;
-    };
-    /** DiagnosticsRequest */
-    DiagnosticsRequest: {
-      /**
-       * Frontend Logs
-       * @default []
-       */
-      frontend_logs: Record<string, never>[];
-      /**
-       * Description
-       * @default
-       */
-      description: string;
-      /**
-       * Browser Info
-       * @default
-       */
-      browser_info: string;
-      /**
-       * Current Route
-       * @default
-       */
-      current_route: string;
-      /**
-       * Click Timestamp
-       * @default 0
-       */
-      click_timestamp: number;
-    };
-    /** AuditEntryRequest */
-    AuditEntryRequest: {
-      /** Device Id */
-      device_id: string;
-      /** Category */
-      category: string;
-      /** Event */
-      event: string;
-      /** Step */
-      step?: number;
-      /** Detail */
-      detail?: string;
-      /** Timestamp */
-      timestamp?: string;
-    };
-    /** AuditEntryResponse */
-    AuditEntryResponse: {
-      /** Success */
-      success: boolean;
-      /** Id */
-      id: number;
-    };
-    /** AuditBatchRequest */
-    AuditBatchRequest: {
-      /** Entries */
-      entries: components["schemas"]["AuditEntryRequest"][];
-    };
-    /** AuditBatchResponse */
-    AuditBatchResponse: {
-      /** Success */
-      success: boolean;
-      /** Count */
-      count: number;
-    };
-    /** ConfigSnapshotRequest */
-    ConfigSnapshotRequest: {
-      /** Device Id */
-      device_id: string;
-      /** File Path */
-      file_path: string;
-      /** Content */
-      content: string;
-      /** Trigger */
-      trigger?: string;
-      /** Timestamp */
-      timestamp?: string;
-    };
-    /** ConfigSnapshotResponse */
-    ConfigSnapshotResponse: {
-      /** Success */
-      success: boolean;
-      /** Id */
-      id: number;
-    };
-    /** FrontendLogEntry */
-    FrontendLogEntry: {
-      /**
-       * Timestamp
-       * @default
-       */
-      timestamp: string;
-      /**
-       * Level
-       * @default
-       */
-      level: string;
-      /**
-       * Message
-       * @default
-       */
-      message: string;
-    };
-    /**
-     * LogDownloadRequest
-     * @description Response with domain redirect verification result.
-     */
-    LogDownloadRequest: {
-      /**
-       * Frontend Logs
-       * @default []
-       */
-      frontend_logs: components["schemas"]["FrontendLogEntry"][];
     };
     /**
      * WizardCompleteRequest
@@ -4449,6 +4830,139 @@ export interface operations {
       };
     };
   };
+  streaming_stats_usage_streaming_stats_usage_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+    };
+  };
+  streaming_token_streaming_device__device_id__streaming_token_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        device_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  blacklist_check_v1_blacklist__device_id__get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        device_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  blacklist_check_v1_blacklist__device_id__post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        device_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  set_marge_account_setMargeAccount_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": unknown;
+        };
+      };
+    };
+  };
   get_playlist_m3u_playlist__device_id___preset_number__m3u_get: {
     parameters: {
       query?: never;
@@ -5018,6 +5532,105 @@ export interface operations {
       };
     };
   };
+  wizard_account_pairing_api_setup_wizard_account_pairing_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AccountPairingRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AccountPairingResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  wizard_ensure_account_api_setup_wizard_ensure_account_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AccountPairingRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AccountPairingResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  wizard_init_persistence_api_setup_wizard_init_persistence_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["InitPersistenceRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["InitPersistenceResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
   wizard_complete_api_setup_wizard_complete_post: {
     parameters: {
       query?: never;
@@ -5104,7 +5717,7 @@ export interface operations {
       };
     };
   };
-  firmware_download_ced_eup_downloads_rel__filename__get: {
+  firmware_download_legacy_ced_eup_downloads_rel__filename__get: {
     parameters: {
       query?: never;
       header?: never;
@@ -5183,6 +5796,13 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["ZoneStatus"][];
         };
+      };
+      /** @description Failed to get zones */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };
@@ -5382,26 +6002,6 @@ export interface operations {
       };
     };
   };
-  health_check_health_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": unknown;
-        };
-      };
-    };
-  };
   get_log_level_api_logs_level_get: {
     parameters: {
       query?: never;
@@ -5411,7 +6011,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description Current log level */
+      /** @description Successful Response */
       200: {
         headers: {
           [name: string]: unknown;
@@ -5435,7 +6035,7 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Updated log level */
+      /** @description Successful Response */
       200: {
         headers: {
           [name: string]: unknown;
@@ -5451,9 +6051,18 @@ export interface operations {
         };
         content?: never;
       };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
   };
-  download_backend_log_api_logs_backend_get: {
+  download_backend_logs_get_api_logs_backend_get: {
     parameters: {
       query?: never;
       header?: never;
@@ -5462,7 +6071,7 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description Plain-text log file download */
+      /** @description Successful Response */
       200: {
         headers: {
           [name: string]: unknown;
@@ -5473,7 +6082,7 @@ export interface operations {
       };
     };
   };
-  download_backend_log_api_logs_backend_post: {
+  download_backend_logs_post_api_logs_backend_post: {
     parameters: {
       query?: never;
       header?: never;
@@ -5486,7 +6095,7 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Plain-text log file download */
+      /** @description Successful Response */
       200: {
         headers: {
           [name: string]: unknown;
@@ -5495,9 +6104,18 @@ export interface operations {
           "text/plain": string;
         };
       };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
   };
-  submit_bug_report_api_bug_report_post: {
+  create_bug_report_api_bug_report_post: {
     parameters: {
       query?: never;
       header?: never;
@@ -5510,7 +6128,7 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Bug report submitted successfully */
+      /** @description Successful Response */
       200: {
         headers: {
           [name: string]: unknown;
@@ -5519,12 +6137,14 @@ export interface operations {
           "application/json": components["schemas"]["BugReportResponse"];
         };
       };
-      /** @description GitHub token not configured */
-      503: {
+      /** @description Validation Error */
+      422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
       };
     };
   };
@@ -5541,13 +6161,22 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Gzipped diagnostic log file */
+      /** @description Successful Response */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
-          "application/gzip": string;
+          "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };
@@ -5565,7 +6194,7 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Entry recorded */
+      /** @description Successful Response */
       200: {
         headers: {
           [name: string]: unknown;
@@ -5574,12 +6203,14 @@ export interface operations {
           "application/json": components["schemas"]["AuditEntryResponse"];
         };
       };
-      /** @description Wizard audit repository not initialized */
-      503: {
+      /** @description Validation Error */
+      422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
       };
     };
   };
@@ -5596,7 +6227,7 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Batch recorded */
+      /** @description Successful Response */
       200: {
         headers: {
           [name: string]: unknown;
@@ -5605,12 +6236,14 @@ export interface operations {
           "application/json": components["schemas"]["AuditBatchResponse"];
         };
       };
-      /** @description Wizard audit repository not initialized */
-      503: {
+      /** @description Validation Error */
+      422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
       };
     };
   };
@@ -5627,7 +6260,7 @@ export interface operations {
       };
     };
     responses: {
-      /** @description Snapshot stored */
+      /** @description Successful Response */
       200: {
         headers: {
           [name: string]: unknown;
@@ -5636,12 +6269,34 @@ export interface operations {
           "application/json": components["schemas"]["ConfigSnapshotResponse"];
         };
       };
-      /** @description Wizard audit repository not initialized */
-      503: {
+      /** @description Validation Error */
+      422: {
         headers: {
           [name: string]: unknown;
         };
-        content?: never;
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  health_check_health_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": unknown;
+        };
       };
     };
   };

--- a/apps/frontend/src/components/AboutSection.css
+++ b/apps/frontend/src/components/AboutSection.css
@@ -144,3 +144,27 @@
   font-size: 16px;
   color: var(--color-text-tertiary, #555);
 }
+
+/* Credits section */
+.about-credits-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+  font-size: 15px;
+  font-weight: var(--font-weight-bold, 700);
+  color: var(--color-text-primary, #ffffff);
+  margin: 0 0 4px;
+}
+
+.about-credits-description {
+  font-size: 13px;
+  color: var(--color-text-secondary, #888);
+  line-height: 1.4;
+  margin: 0 0 var(--space-sm, 8px);
+}
+
+.about-contributor-detail {
+  font-weight: normal;
+  font-size: 12px;
+  color: var(--color-text-secondary, #888);
+}

--- a/apps/frontend/src/components/AboutSection.tsx
+++ b/apps/frontend/src/components/AboutSection.tsx
@@ -9,6 +9,29 @@ const GITHUB_URL = "https://github.com/scheilch/opencloudtouch";
 const ISSUES_URL = "https://github.com/scheilch/opencloudtouch/issues/new?template=bug_report.yml";
 const BMC_URL = "https://buymeacoffee.com/b49rjg5k6vj";
 
+const CONTRIBUTORS = [
+  {
+    name: "Zimbo88",
+    url: "https://github.com/Zimbo88",
+    contribution: "Reverse engineering, factory-reset fix, persistence initialization",
+  },
+  {
+    name: "danielkohl",
+    url: "https://github.com/danielkohl",
+    contribution: "Root cause discovery (HTTPS→HTTP protocol fix), first working manual fix",
+  },
+  {
+    name: "ubittner",
+    url: "https://github.com/ubittner",
+    contribution: "margeAccountUUID correlation analysis, systematic debugging",
+  },
+  {
+    name: "bratwurstbraeter",
+    url: "https://github.com/bratwurstbraeter",
+    contribution: "Bosman app discovery that enabled the factory-reset fix",
+  },
+];
+
 export default function AboutSection() {
   const { t } = useTranslation();
   const { data: health, isLoading: healthLoading, isError: healthError } = useHealth();
@@ -81,6 +104,29 @@ export default function AboutSection() {
               >
                 <span className="about-link-icon">{link.icon}</span>
                 <span className="about-link-label">{link.label}</span>
+                <span className="about-link-chevron">{"\u203A"}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+
+        <hr className="about-divider" />
+
+        {/* Community contributors */}
+        <h3 className="about-credits-title">
+          <span className="about-meta-icon">{"\uD83C\uDFC6"}</span>
+          {t("about.creditsTitle")}
+        </h3>
+        <p className="about-credits-description">{t("about.creditsDescription")}</p>
+        <ul className="about-links">
+          {CONTRIBUTORS.map((c) => (
+            <li key={c.name}>
+              <a href={c.url} target="_blank" rel="noopener noreferrer" className="about-link-item">
+                <span className="about-link-icon">{"\uD83D\uDC64"}</span>
+                <span className="about-link-label">
+                  <strong>@{c.name}</strong>
+                  <span className="about-contributor-detail"> — {c.contribution}</span>
+                </span>
                 <span className="about-link-chevron">{"\u203A"}</span>
               </a>
             </li>

--- a/apps/frontend/src/i18n/locales/de.json
+++ b/apps/frontend/src/i18n/locales/de.json
@@ -580,7 +580,9 @@
     "github": "GitHub",
     "reportIssue": "Problem melden",
     "support": "Unterstützen",
-    "versionUnavailable": "Version nicht verfügbar"
+    "versionUnavailable": "Version nicht verfügbar",
+    "creditsTitle": "Mitwirkende",
+    "creditsDescription": "Besonderer Dank an die Community-Mitglieder, die durch Forschung, Tests und Reverse Engineering beigetragen haben."
   },
   "discovery": {
     "started": "Suche gestartet",

--- a/apps/frontend/src/i18n/locales/en.json
+++ b/apps/frontend/src/i18n/locales/en.json
@@ -580,7 +580,9 @@
     "github": "GitHub",
     "reportIssue": "Report a problem",
     "support": "Support",
-    "versionUnavailable": "Version unavailable"
+    "versionUnavailable": "Version unavailable",
+    "creditsTitle": "Contributors",
+    "creditsDescription": "Special thanks to the community members who contributed research, testing, and reverse engineering."
   },
   "discovery": {
     "started": "Discovery started",

--- a/apps/frontend/src/i18n/locales/es.json
+++ b/apps/frontend/src/i18n/locales/es.json
@@ -580,7 +580,9 @@
     "github": "GitHub",
     "reportIssue": "Informar un problema",
     "support": "Apoyo",
-    "versionUnavailable": "Versión no disponible"
+    "versionUnavailable": "Versión no disponible",
+    "creditsTitle": "Colaboradores",
+    "creditsDescription": "Agradecimiento especial a los miembros de la comunidad que contribuyeron con investigación, pruebas e ingeniería inversa."
   },
   "discovery": {
     "started": "Búsqueda iniciada",

--- a/apps/frontend/src/i18n/locales/fr.json
+++ b/apps/frontend/src/i18n/locales/fr.json
@@ -580,7 +580,9 @@
     "github": "GitHub",
     "reportIssue": "Signaler un problème",
     "support": "Assistance",
-    "versionUnavailable": "Version non disponible"
+    "versionUnavailable": "Version non disponible",
+    "creditsTitle": "Contributeurs",
+    "creditsDescription": "Remerciements particuliers aux membres de la communauté qui ont contribué par leurs recherches, tests et rétro-ingénierie."
   },
   "discovery": {
     "started": "Détection démarrée",

--- a/apps/frontend/src/i18n/locales/it.json
+++ b/apps/frontend/src/i18n/locales/it.json
@@ -580,7 +580,9 @@
     "github": "GitHub",
     "reportIssue": "Segnala un problema",
     "support": "Supporto",
-    "versionUnavailable": "Versione non disponibile"
+    "versionUnavailable": "Versione non disponibile",
+    "creditsTitle": "Contributori",
+    "creditsDescription": "Un ringraziamento speciale ai membri della community che hanno contribuito con ricerca, test e reverse engineering."
   },
   "discovery": {
     "started": "Rilevamento avviato",

--- a/apps/frontend/src/i18n/locales/ja.json
+++ b/apps/frontend/src/i18n/locales/ja.json
@@ -580,7 +580,9 @@
     "github": "GitHub",
     "reportIssue": "問題を報告",
     "support": "サポート",
-    "versionUnavailable": "バージョン不明"
+    "versionUnavailable": "バージョン不明",
+    "creditsTitle": "貢献者",
+    "creditsDescription": "リサーチ、テスト、リバースエンジニアリングに貢献してくださったコミュニティメンバーに特別な感謝を。"
   },
   "discovery": {
     "started": "検索開始",

--- a/apps/frontend/src/i18n/locales/nl.json
+++ b/apps/frontend/src/i18n/locales/nl.json
@@ -580,7 +580,9 @@
     "github": "GitHub",
     "reportIssue": "Een probleem melden",
     "support": "Ondersteunen",
-    "versionUnavailable": "Versie niet beschikbaar"
+    "versionUnavailable": "Versie niet beschikbaar",
+    "creditsTitle": "Bijdragers",
+    "creditsDescription": "Speciale dank aan de communityleden die hebben bijgedragen met onderzoek, testen en reverse engineering."
   },
   "discovery": {
     "started": "Zoeken gestart",

--- a/apps/frontend/src/i18n/locales/pl.json
+++ b/apps/frontend/src/i18n/locales/pl.json
@@ -580,7 +580,9 @@
     "github": "GitHub",
     "reportIssue": "Zgłoś problem",
     "support": "Wesprzyj",
-    "versionUnavailable": "Wersja niedostępna"
+    "versionUnavailable": "Wersja niedostępna",
+    "creditsTitle": "Współtwórcy",
+    "creditsDescription": "Szczególne podziękowania dla członków społeczności, którzy przyczynili się do badań, testów i inżynierii wstecznej."
   },
   "discovery": {
     "started": "Wyszukiwanie rozpoczęte",

--- a/apps/frontend/src/i18n/locales/pt-BR.json
+++ b/apps/frontend/src/i18n/locales/pt-BR.json
@@ -580,7 +580,9 @@
     "github": "GitHub",
     "reportIssue": "Relatar um problema",
     "support": "Apoiar",
-    "versionUnavailable": "Versão não disponível"
+    "versionUnavailable": "Versão não disponível",
+    "creditsTitle": "Colaboradores",
+    "creditsDescription": "Agradecimento especial aos membros da comunidade que contribuíram com pesquisa, testes e engenharia reversa."
   },
   "discovery": {
     "started": "Busca iniciada",

--- a/apps/frontend/src/i18n/locales/sv.json
+++ b/apps/frontend/src/i18n/locales/sv.json
@@ -580,7 +580,9 @@
     "github": "GitHub",
     "reportIssue": "Rapportera problem",
     "support": "Stöd",
-    "versionUnavailable": "Version ej tillgänglig"
+    "versionUnavailable": "Version ej tillgänglig",
+    "creditsTitle": "Bidragsgivare",
+    "creditsDescription": "Speciellt tack till communitymedlemmarna som bidragit med forskning, testning och reverse engineering."
   },
   "discovery": {
     "started": "Sökning startad",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,7 +15,8 @@ sonar.exclusions=\
   **/build/**,\
   **/*.min.js,\
   **/*.css,\
-  apps/frontend/src/vite-env.d.ts
+  apps/frontend/src/vite-env.d.ts,\
+  apps/frontend/src/api/generated/**
 
 sonar.cpd.exclusions=\
   apps/frontend/src/api/generated/**


### PR DESCRIPTION
## Summary

Adds the **persistence initialization endpoint** for factory-reset SoundTouch devices (resolves #167) and a **contributors credits section** in the About page.

## Changes

### Backend
- **NEW** \POST /wizard/init-persistence\ endpoint — writes \SystemConfigurationDB.xml\ and \Sources.xml\ to \/mnt/nv/BoseApp-Persistence/1/\ via SSH
- **NEW** \persistence_service.py\ — XML generation matching [Zimbo88's script](https://github.com/scheilch/opencloudtouch/issues/167#issuecomment-2867209628) 1:1
- **NEW** \InitPersistenceRequest\ / \InitPersistenceResponse\ API models with Pydantic validation
- **NEW** 22 unit tests for persistence service (all passing)
- Updated \openapi.yaml\ with new endpoint + schemas

### Frontend
- **Contributors section** in AboutSection with credits for Zimbo88, danielkohl, ubittner, bratwurstbraeter
- i18n keys for credits in all 10 locales (en, de, es, fr, it, ja, nl, pl, pt-BR, sv)
- Regenerated OpenAPI types (\schema.ts\)

### Infrastructure
- Excluded \pps/frontend/src/api/generated/**\ from SonarQube analysis

## Testing
- Backend: 1305 unit tests passing
- Frontend: 657 unit tests passing
- TypeScript: clean
- Ruff + Black + Prettier + ESLint: clean
- All pre-commit + pre-push hooks passing

## Context
This is a clean rewrite on \main\ (v1.2.6) after the previous branch was based on the consolidation branch. The persistence init feature addresses the core issue where factory-reset devices lose their \margeAccountUUID\ and can no longer play presets.