### PR TITLE
feat: enable TuneIn support with renamed feature toggle

### DIFF
--- a/apps/frontend/src/components/CloudBadge.tsx
+++ b/apps/frontend/src/components/CloudBadge.tsx
@@ -13,7 +13,7 @@
 
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { HAS_EXT_RESOLVER } from "../config/capabilities";
+import { HAS_TUNEIN_SUPPORT } from "../config/capabilities";
 import "./CloudBadge.css";
 
 interface CloudBadgeProps {
@@ -25,7 +25,7 @@ export default function CloudBadge({ isCloudDependent, source }: CloudBadgeProps
   const { t } = useTranslation();
   const [showTooltip, setShowTooltip] = useState(false);
 
-  if (!HAS_EXT_RESOLVER && isCloudDependent && source === "TUNEIN") {
+  if (!HAS_TUNEIN_SUPPORT && isCloudDependent && source === "TUNEIN") {
     return null;
   }
 

--- a/apps/frontend/src/components/NowPlaying.tsx
+++ b/apps/frontend/src/components/NowPlaying.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { HAS_EXT_RESOLVER } from "../config/capabilities";
+import { HAS_TUNEIN_SUPPORT } from "../config/capabilities";
 import "./NowPlaying.css";
 
 const DEFAULT_ARTWORKS = [
@@ -62,7 +62,7 @@ const SOURCE_BADGE_MAP: Record<string, SourceBadgeConfig> = {
 function getSourceBadge(source?: string) {
   if (!source) return null;
   // TUNEIN only gets a badge when resolver is active
-  if (source === "TUNEIN" && !HAS_EXT_RESOLVER) return null;
+  if (source === "TUNEIN" && !HAS_TUNEIN_SUPPORT) return null;
   const config = source === "TUNEIN" ? SOURCE_BADGE_MAP.INTERNET_RADIO : SOURCE_BADGE_MAP[source];
   if (!config) return null;
   return (

--- a/apps/frontend/src/components/RadioSearch.tsx
+++ b/apps/frontend/src/components/RadioSearch.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { HAS_EXT_RESOLVER } from "../config/capabilities";
+import { HAS_TUNEIN_SUPPORT } from "../config/capabilities";
 import { getErrorMessage, parseApiError } from "../api/types";
 import { getAvatarColor, getStationInitials } from "../utils/stationAvatar";
 import StationDetail from "./StationDetail";
@@ -58,11 +58,11 @@ const SEARCH_TYPES: { value: SearchType }[] = [
 ];
 
 const ALL_PROVIDERS: { value: RadioProviderType; label: string }[] = [
-  { value: "radiobrowser", label: "RadioBrowser" },
   { value: "tunein", label: "TuneIn" },
+  { value: "radiobrowser", label: "RadioBrowser" },
 ];
 
-const PROVIDERS = HAS_EXT_RESOLVER
+const PROVIDERS = HAS_TUNEIN_SUPPORT
   ? ALL_PROVIDERS
   : ALL_PROVIDERS.filter((p) => p.value !== "tunein");
 
@@ -80,7 +80,9 @@ export default function RadioSearch({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchType, setSearchType] = useState<SearchType>("name");
-  const [radioProvider, setRadioProvider] = useState<RadioProviderType>("radiobrowser");
+  const [radioProvider, setRadioProvider] = useState<RadioProviderType>(
+    HAS_TUNEIN_SUPPORT ? "tunein" : "radiobrowser"
+  );
   const [detailUuid, setDetailUuid] = useState<string | null>(null);
   const debounceRef = useRef<number | null>(null);
   const abortRef = useRef<AbortController | null>(null);

--- a/apps/frontend/src/config/capabilities.ts
+++ b/apps/frontend/src/config/capabilities.ts
@@ -1,1 +1,1 @@
-export const HAS_EXT_RESOLVER: boolean = __OCT_EXT_RESOLVER__;
+export const HAS_TUNEIN_SUPPORT: boolean = __TUNEIN_SUPPORTED__;

--- a/apps/frontend/src/vite-env.d.ts
+++ b/apps/frontend/src/vite-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-declare const __OCT_EXT_RESOLVER__: boolean;
+declare const __TUNEIN_SUPPORTED__: boolean;
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;

--- a/apps/frontend/tests/unit/CloudBadge.test.tsx
+++ b/apps/frontend/tests/unit/CloudBadge.test.tsx
@@ -3,7 +3,7 @@ import { render } from "@testing-library/react";
 import CloudBadge from "../../src/components/CloudBadge";
 
 describe("CloudBadge Component", () => {
-  describe("Default behavior (HAS_EXT_RESOLVER=true)", () => {
+  describe("Default behavior (HAS_TUNEIN_SUPPORT=true)", () => {
     it("should render compatible badge when not cloud-dependent", () => {
       const { container } = render(
         <CloudBadge isCloudDependent={false} />
@@ -29,10 +29,10 @@ describe("CloudBadge Component", () => {
     });
   });
 
-  describe("Feature Toggle (HAS_EXT_RESOLVER=false)", () => {
+  describe("Feature Toggle (HAS_TUNEIN_SUPPORT=false)", () => {
     it("should render nothing for TUNEIN cloud-dependent source when flag is false", async () => {
       vi.resetModules();
-      vi.doMock("../../src/config/capabilities", () => ({ HAS_EXT_RESOLVER: false }));
+      vi.doMock("../../src/config/capabilities", () => ({ HAS_TUNEIN_SUPPORT: false }));
       const { default: CloudBadgeGated } = await import("../../src/components/CloudBadge");
 
       const { container } = render(
@@ -47,7 +47,7 @@ describe("CloudBadge Component", () => {
 
     it("should still render compatible badge when flag is false and not cloud-dependent", async () => {
       vi.resetModules();
-      vi.doMock("../../src/config/capabilities", () => ({ HAS_EXT_RESOLVER: false }));
+      vi.doMock("../../src/config/capabilities", () => ({ HAS_TUNEIN_SUPPORT: false }));
       const { default: CloudBadgeGated } = await import("../../src/components/CloudBadge");
 
       const { container } = render(
@@ -61,7 +61,7 @@ describe("CloudBadge Component", () => {
 
     it("should still render dependent badge for non-TUNEIN source when flag is false", async () => {
       vi.resetModules();
-      vi.doMock("../../src/config/capabilities", () => ({ HAS_EXT_RESOLVER: false }));
+      vi.doMock("../../src/config/capabilities", () => ({ HAS_TUNEIN_SUPPORT: false }));
       const { default: CloudBadgeGated } = await import("../../src/components/CloudBadge");
 
       const { container } = render(

--- a/apps/frontend/tests/unit/NowPlaying.test.tsx
+++ b/apps/frontend/tests/unit/NowPlaying.test.tsx
@@ -446,10 +446,10 @@ describe("NowPlaying Component", () => {
     });
   });
 
-  describe("Feature Toggle (HAS_EXT_RESOLVER)", () => {
-    it("should not show badge for TUNEIN source when HAS_EXT_RESOLVER is false", async () => {
+  describe("Feature Toggle (HAS_TUNEIN_SUPPORT)", () => {
+    it("should not show badge for TUNEIN source when HAS_TUNEIN_SUPPORT is false", async () => {
       vi.resetModules();
-      vi.doMock("../../src/config/capabilities", () => ({ HAS_EXT_RESOLVER: false }));
+      vi.doMock("../../src/config/capabilities", () => ({ HAS_TUNEIN_SUPPORT: false }));
       const { default: NowPlayingGated } = await import("../../src/components/NowPlaying");
 
       const nowPlaying = {
@@ -465,7 +465,7 @@ describe("NowPlaying Component", () => {
       vi.doUnmock("../../src/config/capabilities");
     });
 
-    it("should show Radio badge for TUNEIN source when HAS_EXT_RESOLVER is true", () => {
+    it("should show Radio badge for TUNEIN source when HAS_TUNEIN_SUPPORT is true", () => {
       const nowPlaying = {
         station: "TuneIn Station",
         source: "TUNEIN",
@@ -479,7 +479,7 @@ describe("NowPlaying Component", () => {
 
     it("should always show Radio badge for INTERNET_RADIO regardless of flag", async () => {
       vi.resetModules();
-      vi.doMock("../../src/config/capabilities", () => ({ HAS_EXT_RESOLVER: false }));
+      vi.doMock("../../src/config/capabilities", () => ({ HAS_TUNEIN_SUPPORT: false }));
       const { default: NowPlayingGated } = await import("../../src/components/NowPlaying");
 
       const nowPlaying = {

--- a/apps/frontend/tests/unit/RadioSearch.test.tsx
+++ b/apps/frontend/tests/unit/RadioSearch.test.tsx
@@ -397,10 +397,10 @@ describe("RadioSearch Component", () => {
     expect(nativeDialog).not.toBeInTheDocument();
   });
 
-  describe("Feature Toggle (HAS_EXT_RESOLVER)", () => {
-    it("should hide provider row when HAS_EXT_RESOLVER is false (only 1 provider)", async () => {
+  describe("Feature Toggle (HAS_TUNEIN_SUPPORT)", () => {
+    it("should hide provider row when HAS_TUNEIN_SUPPORT is false (only 1 provider)", async () => {
       vi.resetModules();
-      vi.doMock("../../src/config/capabilities", () => ({ HAS_EXT_RESOLVER: false }));
+      vi.doMock("../../src/config/capabilities", () => ({ HAS_TUNEIN_SUPPORT: false }));
       const { default: RadioSearchGated } = await import("../../src/components/RadioSearch");
 
       const { container } = render(
@@ -418,7 +418,7 @@ describe("RadioSearch Component", () => {
       vi.doUnmock("../../src/config/capabilities");
     });
 
-    it("should show provider row with TuneIn chip when HAS_EXT_RESOLVER is true", () => {
+    it("should show provider row with TuneIn chip when HAS_TUNEIN_SUPPORT is true", () => {
       const { container } = render(
         <RadioSearch isOpen={true} onStationSelect={mockOnStationSelect} onClose={mockOnClose} />
       );

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   define: {
-    __OCT_EXT_RESOLVER__: JSON.stringify(false),
+    __TUNEIN_SUPPORTED__: JSON.stringify(true),
   },
   build: {
     outDir: '../../.out/dist',

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -5,7 +5,7 @@ import path from 'path'
 export default defineConfig({
   plugins: [react()],
   define: {
-    __OCT_EXT_RESOLVER__: JSON.stringify(true),
+    __TUNEIN_SUPPORTED__: JSON.stringify(true),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- Rename __OCT_EXT_RESOLVER__ to __TUNEIN_SUPPORTED__
- Rename HAS_EXT_RESOLVER to HAS_TUNEIN_SUPPORT
- Enable TuneIn by default (flag set to true)
- Set TuneIn as default radio provider
- Reorder provider chips: TuneIn before RadioBrowser