### PR TITLE
fix(issue-handler): handle 410 Gone for deleted issues

### DIFF
--- a/scripts/issue_handler/github_client.py
+++ b/scripts/issue_handler/github_client.py
@@ -174,9 +174,9 @@ class GitHubClient:
         )
 
     async def get_issue_state(self, issue_number: int) -> str:
-        """Get current issue state. Returns 'deleted' if 404."""
+        """Get current issue state. Returns 'deleted' if 404/410."""
         response = await self._bot_client.get(self._repo_url(f"/issues/{issue_number}"))
-        if response.status_code == 404:
+        if response.status_code in (404, 410):
             return "deleted"
         response.raise_for_status()
         return response.json().get("state", "unknown")

--- a/scripts/issue_handler/tests/test_github_client.py
+++ b/scripts/issue_handler/tests/test_github_client.py
@@ -161,6 +161,12 @@ class TestIssueStateCheck:
             assert state == "deleted"
 
     @pytest.mark.asyncio
+    async def test_get_issue_state_gone(self, client: GitHubClient) -> None:
+        with patch.object(client._bot_client, "get", new_callable=AsyncMock, return_value=_resp(410, {"message": "Gone"}, "GET")):
+            state = await client.get_issue_state(42)
+            assert state == "deleted"
+
+    @pytest.mark.asyncio
     async def test_get_issue_state_closed(self, client: GitHubClient) -> None:
         with patch.object(client._bot_client, "get", new_callable=AsyncMock, return_value=_resp(200, {"state": "closed"}, "GET")):
             state = await client.get_issue_state(42)


### PR DESCRIPTION
## Problem
Issue handler crashes with \410 Gone\ when processing events for deleted issues (#263).

## Fix
- \get_issue_state()\ now treats HTTP 410 same as 404 (returns \deleted\)
- Added test for 410 Gone response

## Evidence
\\\
[ERROR] Client error '410 Gone' for url 'https://api.github.com/repos/opencloudtouch/opencloudtouch/issues/263'
\\\
https://github.com/opencloudtouch/opencloudtouch/actions/runs/26397725258