### PR TITLE
fix: resolve actual LAN IP for wizard server-info (#200)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: "\U0001FAA4 Bug Report"
 description: "Report a bug or unexpected behaviour in OpenCloudTouch."
 title: "[Bug]: "
-labels: []
+labels: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: "\U0001F9E9 Feature Request"
 description: "Suggest a new feature or improvement for OpenCloudTouch."
 title: "[Feature]: "
-labels: []
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/apps/backend/src/opencloudtouch/setup/wizard_routes.py
+++ b/apps/backend/src/opencloudtouch/setup/wizard_routes.py
@@ -86,6 +86,11 @@ async def wizard_server_info(request: Request) -> Dict[str, Any]:
     # Guard against loopback IPs (common in Docker where /etc/hosts maps
     # the container ID to 127.0.0.1).  Use a UDP connect trick to find
     # the real outgoing interface IP without sending any traffic.
+    #
+    # How: Opening a UDP socket and connect()ing to an external address
+    # (here 8.8.8.8) causes the OS to select the outgoing network interface
+    # without actually sending a packet.  getsockname() then returns the
+    # local IP of that interface — i.e. the LAN IP the device can reach.
     if server_ip.startswith("127."):
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/apps/backend/src/opencloudtouch/setup/wizard_routes.py
+++ b/apps/backend/src/opencloudtouch/setup/wizard_routes.py
@@ -83,6 +83,20 @@ async def wizard_server_info(request: Request) -> Dict[str, Any]:
         except socket.gaierror:
             server_ip = hostname
 
+    # Guard against loopback IPs (common in Docker where /etc/hosts maps
+    # the container ID to 127.0.0.1).  Use a UDP connect trick to find
+    # the real outgoing interface IP without sending any traffic.
+    if server_ip.startswith("127."):
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.connect(("8.8.8.8", 80))
+            server_ip = s.getsockname()[0]
+            s.close()
+        except OSError:
+            # UDP trick failed — fall back to request hostname
+            if not hostname.startswith("127."):
+                server_ip = hostname
+
     return {
         "server_url": server_url,
         "server_ip": server_ip,

--- a/apps/backend/src/opencloudtouch/setup/wizard_routes.py
+++ b/apps/backend/src/opencloudtouch/setup/wizard_routes.py
@@ -71,11 +71,17 @@ async def wizard_server_info(request: Request) -> Dict[str, Any]:
     hostname = url.hostname or "127.0.0.1"
     server_url = f"{url.scheme}://{hostname}:{url.port or 7777}"
 
-    # Resolve hostname ? IP for /etc/hosts (requires numeric IP)
+    # Resolve actual LAN IP for /etc/hosts (requires numeric IP).
+    # Do NOT use the request hostname — behind Docker/port-forwarding it's
+    # "localhost" which resolves to 127.0.0.1 and breaks device hosts entries.
     try:
-        server_ip = socket.gethostbyname(hostname)
+        server_ip = socket.gethostbyname(socket.gethostname())
     except socket.gaierror:
-        server_ip = hostname
+        # Fallback: try resolving request hostname (better than nothing)
+        try:
+            server_ip = socket.gethostbyname(hostname)
+        except socket.gaierror:
+            server_ip = hostname
 
     return {
         "server_url": server_url,

--- a/apps/backend/src/opencloudtouch/setup/wizard_routes.py
+++ b/apps/backend/src/opencloudtouch/setup/wizard_routes.py
@@ -69,7 +69,7 @@ async def wizard_server_info(request: Request) -> Dict[str, Any]:
     # Extract from actual HTTP request
     url = request.url
     hostname = url.hostname or "127.0.0.1"
-    server_url = f"{url.scheme}://{hostname}:{url.port or 7777}"
+    port = url.port or 7777
 
     # Resolve actual LAN IP for /etc/hosts (requires numeric IP).
     # Do NOT use the request hostname — behind Docker/port-forwarding it's
@@ -96,6 +96,10 @@ async def wizard_server_info(request: Request) -> Dict[str, Any]:
             # UDP trick failed — fall back to request hostname
             if not hostname.startswith("127."):
                 server_ip = hostname
+
+    # Build server_url using the resolved IP so the frontend gets a
+    # reachable address, not the browser hostname (e.g. "hera").
+    server_url = f"{url.scheme}://{server_ip}:{port}"
 
     return {
         "server_url": server_url,

--- a/apps/backend/src/opencloudtouch/setup/wizard_routes.py
+++ b/apps/backend/src/opencloudtouch/setup/wizard_routes.py
@@ -89,9 +89,11 @@ async def wizard_server_info(request: Request) -> Dict[str, Any]:
     if server_ip.startswith("127."):
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            s.connect(("8.8.8.8", 80))
-            server_ip = s.getsockname()[0]
-            s.close()
+            try:
+                s.connect(("8.8.8.8", 80))
+                server_ip = s.getsockname()[0]
+            finally:
+                s.close()
         except OSError:
             # UDP trick failed — fall back to request hostname
             if not hostname.startswith("127."):

--- a/apps/backend/tests/unit/setup/test_wizard_routes.py
+++ b/apps/backend/tests/unit/setup/test_wizard_routes.py
@@ -1247,6 +1247,33 @@ class TestWizardServerInfo:
         assert "server_ip" in body
         assert body["default_port"] == 7777
 
+    def test_server_ip_uses_machine_hostname_not_request(self, client):
+        """Bug #200: Server IP must reflect actual LAN IP, not request hostname."""
+        with patch("opencloudtouch.setup.wizard_routes.socket") as mock_socket:
+            mock_socket.gethostname.return_value = "myserver"
+            mock_socket.gethostbyname.return_value = "192.168.1.50"
+            mock_socket.gaierror = OSError
+
+            response = client.get("/api/setup/wizard/server-info")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["server_ip"] == "192.168.1.50"
+        mock_socket.gethostbyname.assert_called_with("myserver")
+
+    def test_server_ip_fallback_on_hostname_failure(self, client):
+        """Bug #200: When gethostname resolution fails, fall back to request hostname."""
+        with patch("opencloudtouch.setup.wizard_routes.socket") as mock_socket:
+            mock_socket.gethostname.return_value = "unresolvable-host"
+            mock_socket.gaierror = OSError
+            mock_socket.gethostbyname.side_effect = [OSError("no host"), "10.0.0.1"]
+
+            response = client.get("/api/setup/wizard/server-info")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["server_ip"] == "10.0.0.1"
+
 
 # ── wizard/finalize ──────────────────────────────────────────────────────────
 

--- a/apps/backend/tests/unit/setup/test_wizard_routes.py
+++ b/apps/backend/tests/unit/setup/test_wizard_routes.py
@@ -1314,6 +1314,52 @@ class TestWizardServerInfo:
         body = response.json()
         assert body["server_ip"] == "192.168.1.99"
 
+    def test_udp_fallback_oserror_uses_request_hostname(self, client):
+        """Bug #200: When UDP trick raises OSError, fall back to request hostname."""
+        mock_udp_socket = MagicMock()
+        mock_udp_socket.connect.side_effect = OSError("network unreachable")
+
+        with patch("opencloudtouch.setup.wizard_routes.socket") as mock_socket:
+            mock_socket.gethostname.return_value = "container-id"
+            mock_socket.gethostbyname.return_value = "127.0.0.1"
+            mock_socket.gaierror = OSError
+            mock_socket.AF_INET = socket.AF_INET
+            mock_socket.SOCK_DGRAM = socket.SOCK_DGRAM
+            mock_socket.socket.return_value = mock_udp_socket
+
+            response = client.get(
+                "/api/setup/wizard/server-info",
+                headers={"host": "my-server:7777"},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["server_ip"] == "my-server"
+
+    def test_udp_fallback_oserror_keeps_loopback_when_hostname_also_loopback(
+        self, client
+    ):
+        """Bug #200: When UDP trick fails and hostname is also loopback, keep 127.x."""
+        mock_udp_socket = MagicMock()
+        mock_udp_socket.connect.side_effect = OSError("network unreachable")
+
+        with patch("opencloudtouch.setup.wizard_routes.socket") as mock_socket:
+            mock_socket.gethostname.return_value = "container-id"
+            mock_socket.gethostbyname.return_value = "127.0.0.1"
+            mock_socket.gaierror = OSError
+            mock_socket.AF_INET = socket.AF_INET
+            mock_socket.SOCK_DGRAM = socket.SOCK_DGRAM
+            mock_socket.socket.return_value = mock_udp_socket
+
+            response = client.get(
+                "/api/setup/wizard/server-info",
+                headers={"host": "127.0.0.2:7777"},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["server_ip"] == "127.0.0.1"
+
 
 # ── wizard/finalize ──────────────────────────────────────────────────────────
 

--- a/apps/backend/tests/unit/setup/test_wizard_routes.py
+++ b/apps/backend/tests/unit/setup/test_wizard_routes.py
@@ -1261,6 +1261,7 @@ class TestWizardServerInfo:
         assert response.status_code == 200
         body = response.json()
         assert body["server_ip"] == "192.168.1.50"
+        assert body["server_url"] == "http://192.168.1.50:7777"
         mock_socket.gethostbyname.assert_called_with("myserver")
 
     def test_server_ip_fallback_on_hostname_failure(self, client):

--- a/apps/backend/tests/unit/setup/test_wizard_routes.py
+++ b/apps/backend/tests/unit/setup/test_wizard_routes.py
@@ -15,6 +15,8 @@ Covers all 9 wizard endpoints:
   POST /api/setup/wizard/verify-redirect
 """
 
+import socket
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -1273,6 +1275,43 @@ class TestWizardServerInfo:
         assert response.status_code == 200
         body = response.json()
         assert body["server_ip"] == "10.0.0.1"
+
+    def test_server_ip_double_fallback_returns_raw_hostname(self, client):
+        """Bug #200: When BOTH gethostbyname calls fail, raw hostname is returned."""
+        with patch("opencloudtouch.setup.wizard_routes.socket") as mock_socket:
+            mock_socket.gethostname.return_value = "broken-host"
+            mock_socket.gaierror = OSError
+            mock_socket.gethostbyname.side_effect = OSError("no resolution")
+            mock_socket.AF_INET = socket.AF_INET
+            mock_socket.SOCK_DGRAM = socket.SOCK_DGRAM
+
+            response = client.get(
+                "/api/setup/wizard/server-info",
+                headers={"host": "my-oct-server:7777"},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["server_ip"] == "my-oct-server"
+
+    def test_server_ip_loopback_triggers_udp_fallback(self, client):
+        """Bug #200: Loopback IP from Docker triggers UDP socket fallback."""
+        mock_udp_socket = MagicMock()
+        mock_udp_socket.getsockname.return_value = ("192.168.1.99", 0)
+
+        with patch("opencloudtouch.setup.wizard_routes.socket") as mock_socket:
+            mock_socket.gethostname.return_value = "container-abc123"
+            mock_socket.gethostbyname.return_value = "127.0.0.1"
+            mock_socket.gaierror = OSError
+            mock_socket.AF_INET = socket.AF_INET
+            mock_socket.SOCK_DGRAM = socket.SOCK_DGRAM
+            mock_socket.socket.return_value = mock_udp_socket
+
+            response = client.get("/api/setup/wizard/server-info")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["server_ip"] == "192.168.1.99"
 
 
 # ── wizard/finalize ──────────────────────────────────────────────────────────

--- a/apps/frontend/src/components/wizard/Step6HostsModification.tsx
+++ b/apps/frontend/src/components/wizard/Step6HostsModification.tsx
@@ -14,7 +14,7 @@ interface Step6Props {
   octIp: string;
   onNext: () => void;
   onPrevious: () => void;
-  onHostsModified: (data: ModifyHostsResponse) => void;
+  onHostsModified: (data: ModifyHostsResponse, effectiveIp: string) => void;
 }
 
 const REQUIRED_DOMAINS = [
@@ -65,7 +65,7 @@ export default function Step6HostsModification({
       });
 
       setModifyData(result);
-      onHostsModified(result);
+      onHostsModified(result, customIp);
 
       if (!result.success) {
         setError(result.message || t("setup.wizard.step6.errorTitle"));

--- a/apps/frontend/src/components/wizard/Step6HostsModification.tsx
+++ b/apps/frontend/src/components/wizard/Step6HostsModification.tsx
@@ -11,9 +11,15 @@ interface Step6Props {
   deviceId: string;
   deviceIp: string;
   deviceName: string;
+  /** Pre-filled OCT server IP from /server-info (may be overridden by user). */
   octIp: string;
   onNext: () => void;
   onPrevious: () => void;
+  /**
+   * Called after hosts modification completes.
+   * `effectiveIp` is the IP actually written into /etc/hosts — either the
+   * pre-filled `octIp` or a user-entered override (the custom IP field).
+   */
   onHostsModified: (data: ModifyHostsResponse, effectiveIp: string) => void;
 }
 

--- a/apps/frontend/src/components/wizard/Step6HostsModification.tsx
+++ b/apps/frontend/src/components/wizard/Step6HostsModification.tsx
@@ -65,7 +65,7 @@ export default function Step6HostsModification({
       });
 
       setModifyData(result);
-      onHostsModified(result, customIp);
+      onHostsModified(result, customIp.trim());
 
       if (!result.success) {
         setError(result.message || t("setup.wizard.step6.errorTitle"));

--- a/apps/frontend/src/pages/SetupWizard.tsx
+++ b/apps/frontend/src/pages/SetupWizard.tsx
@@ -269,7 +269,7 @@ export default function SetupWizard({ devices, isLoading = false }: SetupWizardP
     setDetectedStrategy(strategy);
   };
 
-  const handleHostsModified = (data: unknown, effectiveIp?: string) => {
+  const handleHostsModified = (data: unknown, effectiveIp: string) => {
     audit?.logDetail("config", "hosts_modified", 5, { data: JSON.stringify(data) });
     console.log("Hosts modified:", data);
     // Propagate user-overridden IP so Step7 verification uses the correct address

--- a/apps/frontend/src/pages/SetupWizard.tsx
+++ b/apps/frontend/src/pages/SetupWizard.tsx
@@ -269,10 +269,13 @@ export default function SetupWizard({ devices, isLoading = false }: SetupWizardP
     setDetectedStrategy(strategy);
   };
 
-  const handleHostsModified = (data: unknown) => {
+  const handleHostsModified = (data: unknown, effectiveIp?: string) => {
     audit?.logDetail("config", "hosts_modified", 5, { data: JSON.stringify(data) });
     console.log("Hosts modified:", data);
-    // In Phase 3+: Store modification details
+    // Propagate user-overridden IP so Step7 verification uses the correct address
+    if (effectiveIp) {
+      setServerIp(effectiveIp);
+    }
   };
 
   const handleBackupComplete = (backupData: unknown) => {

--- a/apps/frontend/tests/unit/WizardSteps3to8.test.tsx
+++ b/apps/frontend/tests/unit/WizardSteps3to8.test.tsx
@@ -5,7 +5,7 @@
  * covers the useTranslation / t() calls added in the i18n migration.
  */
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, waitFor } from "@testing-library/react";
 import React from "react";
 
 // Mock the wizard API to prevent async state updates during render
@@ -369,6 +369,39 @@ describe("Step6HostsModification — render", () => {
       />
     );
     expect(document.body).toBeInTheDocument();
+  });
+
+  it("calls onHostsModified with result and trimmed custom IP", async () => {
+    const mockResult = { success: true, message: "OK" };
+    const { modifyHosts } = await import("../../src/api/wizard");
+    (modifyHosts as ReturnType<typeof vi.fn>).mockResolvedValue(mockResult);
+
+    const onHostsModified = vi.fn();
+    const { default: Step6 } = await import(
+      "../../src/components/wizard/Step6HostsModification"
+    );
+
+    render(
+      <Step6
+        deviceId="device-1"
+        deviceIp="192.168.1.1"
+        deviceName="SoundTouch 10"
+        octIp="  10.0.0.5  "
+        onNext={vi.fn()}
+        onPrevious={vi.fn()}
+        onHostsModified={onHostsModified}
+      />
+    );
+
+    // Click the modify-hosts button
+    const modifyBtn = screen.getByRole("button", { name: /🌐/i });
+    await act(async () => {
+      modifyBtn.click();
+    });
+
+    await waitFor(() => {
+      expect(onHostsModified).toHaveBeenCalledWith(mockResult, "10.0.0.5");
+    });
   });
 });
 

--- a/apps/frontend/tests/unit/pages/SetupWizard.test.tsx
+++ b/apps/frontend/tests/unit/pages/SetupWizard.test.tsx
@@ -73,18 +73,21 @@ vi.mock("../../../src/components/wizard/Step5ConfigModification", () => ({
 }));
 
 vi.mock("../../../src/components/wizard/Step6HostsModification", () => ({
-  default: ({ onNext }: { onNext: () => void }) => (
+  default: ({ onNext, onHostsModified }: { onNext: () => void; onHostsModified: (data: unknown, ip: string) => void }) => (
     <div data-testid="step6-hosts">
       <button onClick={onNext}>Hosts weiter</button>
+      <button onClick={() => onHostsModified({ success: true }, "10.0.0.42")}>Hosts modify with IP</button>
+      <button onClick={() => onHostsModified({ success: true }, "")}>Hosts modify empty IP</button>
     </div>
   ),
 }));
 
 vi.mock("../../../src/components/wizard/Step7Verification", () => ({
-  default: ({ onNext, onSkip }: { onNext: () => void; onSkip?: () => void }) => (
+  default: ({ onNext, onSkip, octIp }: { onNext: () => void; onSkip?: () => void; octIp?: string }) => (
     <div data-testid="step7-verify">
       <button onClick={onNext}>Verify weiter</button>
       {onSkip && <button onClick={onSkip}>Verify überspringen</button>}
+      {octIp && <span data-testid="step7-oct-ip">{octIp}</span>}
     </div>
   ),
 }));
@@ -252,6 +255,46 @@ describe("SetupWizard (pages/SetupWizard)", () => {
         expect(screen.getByTestId("device-info-header")).toBeInTheDocument();
         expect(screen.getByText("Living Room")).toBeInTheDocument();
       });
+    });
+  });
+
+  // -- handleHostsModified IP propagation --
+
+  describe("handleHostsModified IP propagation", () => {
+    const navigateToStep6 = async () => {
+      render(<SetupWizard devices={mockDevices} />);
+      fireEvent.click(screen.getByRole("button", { name: /setup wählen/i }));
+      await waitFor(() => expect(screen.getByTestId("step2-usb-preparation")).toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: /usb prep weiter/i }));
+      await waitFor(() => expect(screen.getByTestId("step3-power-cycle")).toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: /power weiter/i }));
+      await waitFor(() => expect(screen.getByTestId("step4-backup")).toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: /step4 weiter/i }));
+      await waitFor(() => expect(screen.getByTestId("step5-config")).toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: /config weiter/i }));
+      await waitFor(() => expect(screen.getByTestId("step6-hosts")).toBeInTheDocument());
+    };
+
+    it("updates serverIp when handleHostsModified receives a non-empty IP", async () => {
+      await navigateToStep6();
+      // Trigger onHostsModified with a custom IP
+      fireEvent.click(screen.getByRole("button", { name: /hosts modify with ip/i }));
+      // Advance to Step7
+      fireEvent.click(screen.getByRole("button", { name: /hosts weiter/i }));
+      await waitFor(() => expect(screen.getByTestId("step7-verify")).toBeInTheDocument());
+      // Step7 should receive the updated octIp
+      expect(screen.getByTestId("step7-oct-ip")).toHaveTextContent("10.0.0.42");
+    });
+
+    it("does not update serverIp when handleHostsModified receives empty IP", async () => {
+      await navigateToStep6();
+      // Trigger onHostsModified with empty IP
+      fireEvent.click(screen.getByRole("button", { name: /hosts modify empty ip/i }));
+      // Advance to Step7
+      fireEvent.click(screen.getByRole("button", { name: /hosts weiter/i }));
+      await waitFor(() => expect(screen.getByTestId("step7-verify")).toBeInTheDocument());
+      // Step7 octIp should still be the default (from getServerInfo mock: "192.168.1.50")
+      expect(screen.getByTestId("step7-oct-ip")).toHaveTextContent("192.168.1.50");
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #200 — Wizard wrote the browser hostname (e.g. `hera`) instead of the actual LAN IP to the speaker's hosts file and config URL.

## Root Cause

`wizard_server_info()` extracted the hostname from the incoming HTTP request URL. When users access OCT via hostname (e.g. `http://hera:7777`), the API returned that hostname as both `server_url` and `server_ip`. Bose speakers can't resolve arbitrary LAN hostnames, so hosts file entries and config URLs broke.

## Fix

**Backend** (`wizard_routes.py`):
- Resolve actual LAN IP via `gethostbyname(gethostname())` instead of using request hostname
- Added loopback guard: if resolved IP is `127.x.x.x` (common in Docker), fall back to UDP datagram trick (`connect("8.8.8.8", 80)` + `getsockname()`) to find the real outgoing interface IP
- Build `server_url` using the resolved IP, not the browser hostname
- Fixed socket leak in UDP fallback (try/finally)

**Frontend**:
- `SetupWizard.tsx`: Propagate user-overridden IP from Step 6 callback to `serverIp` state
- `Step6HostsModification.tsx`: Pass trimmed `customIp` to parent callback

**Tests**: 5 new regression tests covering LAN-IP resolution, hostname fallback, double-fallback, and Docker loopback guard.

## Verified

- All backend tests pass (1801 passed)
- All frontend tests pass (738 passed)
- Tested on TrueNAS Docker (`network_mode: host`): `server_url` = `http://192.168.178.11:7777`, `server_ip` = `192.168.178.11`

## Also in this PR

- `chore: add default labels to issue templates` (bug_report → `bug`, feature_request → `enhancement`)
