### PR TITLE
fix: health-check pings correct port (8090) and makes it configurable via OCT_DEVICE_HTTP_PORT

### DIFF
--- a/apps/backend/src/opencloudtouch/devices/health_check.py
+++ b/apps/backend/src/opencloudtouch/devices/health_check.py
@@ -1,8 +1,10 @@
 """Background health-check service for SoundTouch devices.
 
-Periodically pings devices via the SoundTouch API (port 8091) to update
-``last_seen`` and detect offline devices.  For devices with
-``ssh_permanent=True``, also verifies the BMX URL via SSH every 30 min.
+Periodically pings devices via the SoundTouch HTTP API to update
+``last_seen`` and detect offline devices.  The port used for the ping is
+``device_http_port`` from the application config (default 8090, override via
+``OCT_DEVICE_HTTP_PORT``).  For devices with ``ssh_permanent=True``, also
+verifies the BMX URL via SSH every 30 min.
 """
 
 import asyncio
@@ -13,7 +15,6 @@ import httpx
 
 from opencloudtouch.core.config import get_config
 from opencloudtouch.devices.repository import DeviceRepository
-from opencloudtouch.discovery import SOUNDTOUCH_WEBSERVER_PORT
 from opencloudtouch.setup.ssh_client import SoundTouchSSHClient, check_ssh_port
 
 logger = logging.getLogger(__name__)
@@ -106,10 +107,11 @@ class DeviceHealthCheck:
 
     @staticmethod
     async def _ping_device(client: httpx.AsyncClient, ip: str) -> bool:
-        """Ping a single device via GET /info on the WebServer port."""
+        """Ping a single device via GET /info on the configured HTTP port."""
+        port = get_config().device_http_port
         try:
             resp = await client.get(
-                f"http://{ip}:{SOUNDTOUCH_WEBSERVER_PORT}/info"  # NOSONAR — Bose devices only support HTTP
+                f"http://{ip}:{port}/info"  # NOSONAR — Bose devices only support HTTP
             )
             return resp.status_code == 200
         except (httpx.ConnectError, httpx.TimeoutException, httpx.ReadError):

--- a/apps/backend/src/opencloudtouch/discovery/__init__.py
+++ b/apps/backend/src/opencloudtouch/discovery/__init__.py
@@ -7,11 +7,13 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional
 
-# Default HTTP API port for Bose SoundTouch devices
+# Default HTTP API port for Bose SoundTouch devices (/info, /volume, /now_playing, …)
 SOUNDTOUCH_HTTP_PORT = 8090
 
-# SoundTouch WebServer port (device description, /info endpoint)
-SOUNDTOUCH_WEBSERVER_PORT = 8091
+# Port alias kept for backward compatibility — resolves to the same value as
+# SOUNDTOUCH_HTTP_PORT.  The /info endpoint is served on port 8090 on all
+# known SoundTouch devices; use OCT_DEVICE_HTTP_PORT to override at runtime.
+SOUNDTOUCH_WEBSERVER_PORT = SOUNDTOUCH_HTTP_PORT
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- **Bug**: the background health-check was pinging `http://<ip>:8091/info` instead of port **8090**.  
  `SOUNDTOUCH_WEBSERVER_PORT` was set to `8091` in `discovery/__init__.py`, but all known SoundTouch devices (including SoundTouch 10) serve `/info` on port **8090**.  As a result, every ping returned a non-200 response and the device was never marked as reachable, blocking normal playback control.
- **Fix**: remove the wrong constant and drive `_ping_device` from the existing `AppConfig.device_http_port` field (already present, default 8090), which is already user-configurable via the `OCT_DEVICE_HTTP_PORT` env var.
- **Backward compat**: `SOUNDTOUCH_WEBSERVER_PORT` is kept as an alias of `SOUNDTOUCH_HTTP_PORT` (both = 8090) so any third-party code that imports it is not broken.

## Changes

| File | Change |
|---|---|
| `devices/health_check.py` | Drop `SOUNDTOUCH_WEBSERVER_PORT` import; use `get_config().device_http_port` in `_ping_device` |
| `discovery/__init__.py` | Alias `SOUNDTOUCH_WEBSERVER_PORT = SOUNDTOUCH_HTTP_PORT` (8090) with a deprecation note |

## How to reproduce the original bug

```python
from opencloudtouch.discovery import SOUNDTOUCH_WEBSERVER_PORT
print(SOUNDTOUCH_WEBSERVER_PORT)  # 8091 before this fix
```

```bash
# SoundTouch 10 — port 8091 returns 404, port 8090 returns 200
curl -s -o /dev/null -w "%{http_code}" http://<device-ip>:8091/info   # 404
curl -s -o /dev/null -w "%{http_code}" http://<device-ip>:8090/info   # 200
```

## Configuration

No migration needed. To override the port at runtime:

```yaml
# Kubernetes ConfigMap / env
OCT_DEVICE_HTTP_PORT: "8090"   # default — change only if your device uses a non-standard port
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)