### PR TITLE
chore(deps): consolidate all dependabot updates

### DIFF
--- a/apps/backend/requirements-dev.txt
+++ b/apps/backend/requirements-dev.txt
@@ -8,7 +8,7 @@ httpx==0.28.1
 respx==0.23.1
 black==26.3.1
 ruff==0.15.12
-mypy==1.20.2
+mypy==2.1.0
 bandit==1.9.4
 safety==3.7.0
 pre-commit==4.6.0

--- a/apps/backend/requirements-dev.txt
+++ b/apps/backend/requirements-dev.txt
@@ -1,16 +1,16 @@
 -r requirements.txt
 pytest==9.0.3
-pytest-asyncio==1.3.0
+pytest-asyncio==1.4.0
 pytest-cov==7.1.0
 pytest-timeout==2.4.0
 pytest-xdist==3.8.0
 httpx==0.28.1
 respx==0.23.1
-black==26.3.1
-ruff==0.15.12
+black==26.5.1
+ruff==0.15.15
 mypy==1.20.2
 bandit==1.9.4
-safety==3.7.0
+safety==3.8.1
 pre-commit==4.6.0
-commitizen==4.15.0
+commitizen==4.16.2
 types-PyYAML==6.0.12.20260408

--- a/apps/backend/requirements-dev.txt
+++ b/apps/backend/requirements-dev.txt
@@ -13,4 +13,4 @@ bandit==1.9.4
 safety==3.7.0
 pre-commit==4.6.0
 commitizen==4.15.0
-types-PyYAML==6.0.12.20260408
+types-PyYAML==6.0.12.20260518

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -28,7 +28,7 @@
     "clean": "rimraf node_modules dist .vite coverage cypress/screenshots cypress/videos"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.95.2",
+    "@tanstack/react-query": "^5.100.14",
     "flag-icons": "^7.5.0",
     "framer-motion": "^12.38.0",
     "html2canvas": "^1.4.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -55,7 +55,7 @@
     "@vitest/ui": "^4.1.5",
     "axe-core": "^4.11.1",
     "colorette": "^2.0.20",
-    "cypress": "^15.14.2",
+    "cypress": "^15.15.0",
     "cypress-axe": "^1.7.0",
     "eslint": "^10.2.1",
     "globals": "^17.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "opencloudtouch",
-      "version": "1.2.2",
+      "version": "1.2.7",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/frontend"
@@ -34,7 +34,7 @@
     },
     "apps/frontend": {
       "name": "opencloudtouch-frontend",
-      "version": "1.2.2",
+      "version": "1.2.7",
       "dependencies": {
         "@tanstack/react-query": "^5.95.2",
         "flag-icons": "^7.5.0",
@@ -14285,9 +14285,9 @@
       "license": "MIT"
     },
     "node_modules/systeminformation": {
-      "version": "5.31.1",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.1.tgz",
-      "integrity": "sha512-6pRwxoGeV/roJYpsfcP6tN9mep6pPeCtXbUOCdVa0nme05Brwcwdge/fVNhIZn2wuUitAKZm4IYa7QjnRIa9zA==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
+      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "opencloudtouch",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/frontend"
@@ -34,7 +34,7 @@
     },
     "apps/frontend": {
       "name": "opencloudtouch-frontend",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "dependencies": {
         "@tanstack/react-query": "^5.95.2",
         "flag-icons": "^7.5.0",
@@ -63,7 +63,7 @@
         "@vitest/ui": "^4.1.5",
         "axe-core": "^4.11.1",
         "colorette": "^2.0.20",
-        "cypress": "^15.14.2",
+        "cypress": "^15.15.0",
         "cypress-axe": "^1.7.0",
         "eslint": "^10.2.1",
         "globals": "^17.6.0",
@@ -1995,9 +1995,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
-      "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.0.tgz",
+      "integrity": "sha512-wGTQfwDMMMiz/muFw4YbCLwTh0uZsXKK+6zWBzftADpitSi6iM62C8GzEhNcng2srUiGPksOriQkA8zakW2R0g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2017,11 +2017,10 @@
         "qs": "~6.14.1",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^5.0.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^8.3.2"
+        "tunnel-agent": "^0.6.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.17.0"
       }
     },
     "node_modules/@cypress/webpack-preprocessor": {
@@ -5941,14 +5940,14 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.14.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.14.2.tgz",
-      "integrity": "sha512-xMWg/iEImeIThRQZdnf3BFJT1a84apM/R91Feoa4vVWGuYWDphMT5jLhRVTBVlCgi+6axegF1zqhNyjhug2SsQ==",
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.15.0.tgz",
+      "integrity": "sha512-N8qBv3AUYn6xfIG73O5O58kTClUBSZ7a3C08IQFkSGTUdEauJ3BqwTFb/f9KPZgadftoZjllC0XSwD7xNNolbA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.10",
+        "@cypress/request": "^4.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -13830,14 +13829,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14919,16 +14918,6 @@
       "license": "MIT",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "opencloudtouch",
-      "version": "1.2.2",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/frontend"
@@ -34,9 +34,9 @@
     },
     "apps/frontend": {
       "name": "opencloudtouch-frontend",
-      "version": "1.2.2",
+      "version": "1.4.0",
       "dependencies": {
-        "@tanstack/react-query": "^5.95.2",
+        "@tanstack/react-query": "^5.100.14",
         "flag-icons": "^7.5.0",
         "framer-motion": "^12.38.0",
         "html2canvas": "^1.4.1",
@@ -3957,9 +3957,9 @@
       "license": "MIT"
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.100.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.7.tgz",
-      "integrity": "sha512-5R7i6ENJLhVeeJrrUz7jKBXUXv/BJrxf9FQJSkR13bPrb3zOcE8A0Z0PxYCcsKPOsiIlTibrBL/zZbtUO1TFyQ==",
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
+      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3967,12 +3967,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.100.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.7.tgz",
-      "integrity": "sha512-LoISYWz8dOOuQbeIctF8K6yi42TWtR1WPGpwGuRUpF3u79JVVIg/PVR0MQdIA0VSHqD/ydf/b7PhKTkg3I4fLQ==",
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
+      "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.100.7"
+        "@tanstack/query-core": "5.100.14"
       },
       "funding": {
         "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "opencloudtouch",
-      "version": "1.2.2",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/frontend"
@@ -34,7 +34,7 @@
     },
     "apps/frontend": {
       "name": "opencloudtouch-frontend",
-      "version": "1.2.2",
+      "version": "1.4.2",
       "dependencies": {
         "@tanstack/react-query": "^5.95.2",
         "flag-icons": "^7.5.0",
@@ -5161,15 +5161,43 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axios/node_modules/proxy-from-env": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "opencloudtouch",
-      "version": "1.2.2",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/frontend"
@@ -34,7 +34,7 @@
     },
     "apps/frontend": {
       "name": "opencloudtouch-frontend",
-      "version": "1.2.2",
+      "version": "1.4.1",
       "dependencies": {
         "@tanstack/react-query": "^5.95.2",
         "flag-icons": "^7.5.0",
@@ -14469,9 +14469,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
# Consolidate All Dependabot Updates

This PR consolidates all 8 open Dependabot PRs into a single atomic update.

## Merged Dependabot PRs

### npm/yarn Updates (5)
- #197: bump systeminformation from 5.31.1 to 5.31.6
- #238: bump uuid and cypress
- #272: bump tmp from 0.2.5 to 0.2.6
- #256: bump @tanstack/react-query from 5.100.7 to 5.100.14
- #284: bump axios from 1.15.2 to 1.16.1

### Python/pip Updates (3)
- #258: bump types-pyyaml from 6.0.12.20260408 to 6.0.12.20260518 in /apps/backend
- #259: bump mypy from 1.20.2 to 2.1.0 in /apps/backend
- #283: bump the python-minor-patch group across 1 directory with 5 updates (black, ruff, safety, commitizen)

## Testing
- ✅ All backend unit tests passing (1699+ tests)
- ✅ All frontend unit tests passing
- ✅ All pre-commit hooks passing
- ✅ mypy type checking passing

## Closes
Closes #197, #238, #272, #258, #259, #283, #256, #284
