### PR TITLE
fix: sync device names from Bose /info during health check (#271)

### DIFF
--- a/apps/backend/src/opencloudtouch/devices/health_check.py
+++ b/apps/backend/src/opencloudtouch/devices/health_check.py
@@ -76,7 +76,7 @@ class DeviceHealthCheck:
             await asyncio.sleep(PING_INTERVAL)
 
     async def _ping_all_devices(self) -> None:
-        """Ping all devices via SoundTouch HTTP API (port 8091)."""
+        """Ping all devices via SoundTouch HTTP API (port 8090)."""
         devices = await self._device_repo.get_all()
         if not devices:
             return
@@ -89,29 +89,40 @@ class DeviceHealthCheck:
                     continue
                 reachable, device_name = await self._ping_device(client, device.ip)
                 if reachable:
-                    device.last_seen = now
-                    if device_name and device_name != device.name:
-                        logger.info(
-                            "Device %s name changed: '%s' -> '%s'",
-                            device.device_id,
-                            device.name,
-                            device_name,
-                        )
-                        device.name = device_name
-                    await self._device_repo.upsert(device)
+                    await self._handle_reachable(device, device_name, now)
                 else:
-                    # Check if device should be marked offline
-                    if device.last_seen:
-                        seconds_since = (now - device.last_seen).total_seconds()
-                        if seconds_since > OFFLINE_THRESHOLD:
-                            logger.warning(
-                                "Device %s (%s) offline for %.0fs",
-                                device.name,
-                                device.ip,
-                                seconds_since,
-                            )
+                    self._handle_unreachable(device, now)
 
         logger.debug("Health-check ping completed for %d devices", len(devices))
+
+    async def _handle_reachable(
+        self, device, device_name: str | None, now: datetime
+    ) -> None:
+        """Update a reachable device: refresh last_seen and name if changed."""
+        device.last_seen = now
+        if device_name and device_name != device.name:
+            logger.info(
+                "Device %s name changed: '%s' -> '%s'",
+                device.device_id,
+                device.name,
+                device_name,
+            )
+            device.name = device_name
+        await self._device_repo.upsert(device)
+
+    @staticmethod
+    def _handle_unreachable(device, now: datetime) -> None:
+        """Log a warning if the device has been offline beyond the threshold."""
+        if not device.last_seen:
+            return
+        seconds_since = (now - device.last_seen).total_seconds()
+        if seconds_since > OFFLINE_THRESHOLD:
+            logger.warning(
+                "Device %s (%s) offline for %.0fs",
+                device.name,
+                device.ip,
+                seconds_since,
+            )
 
     @staticmethod
     async def _ping_device(

--- a/apps/backend/src/opencloudtouch/devices/health_check.py
+++ b/apps/backend/src/opencloudtouch/devices/health_check.py
@@ -10,6 +10,7 @@ import logging
 from datetime import UTC, datetime
 
 import httpx
+from defusedxml.ElementTree import fromstring as parse_xml_string
 
 from opencloudtouch.core.config import get_config
 from opencloudtouch.devices.repository import DeviceRepository
@@ -86,9 +87,17 @@ class DeviceHealthCheck:
             for device in devices:
                 if not device.ip:
                     continue
-                reachable = await self._ping_device(client, device.ip)
+                reachable, device_name = await self._ping_device(client, device.ip)
                 if reachable:
                     device.last_seen = now
+                    if device_name and device_name != device.name:
+                        logger.info(
+                            "Device %s name changed: '%s' -> '%s'",
+                            device.device_id,
+                            device.name,
+                            device_name,
+                        )
+                        device.name = device_name
                     await self._device_repo.upsert(device)
                 else:
                     # Check if device should be marked offline
@@ -105,17 +114,35 @@ class DeviceHealthCheck:
         logger.debug("Health-check ping completed for %d devices", len(devices))
 
     @staticmethod
-    async def _ping_device(client: httpx.AsyncClient, ip: str) -> bool:
-        """Ping a single device via GET /info on the WebServer port."""
+    async def _ping_device(
+        client: httpx.AsyncClient, ip: str
+    ) -> tuple[bool, str | None]:
+        """Ping a single device via GET /info on the WebServer port.
+
+        Returns:
+            Tuple of (reachable, device_name). device_name is None if
+            the response could not be parsed.
+        """
         try:
             resp = await client.get(
                 f"http://{ip}:{SOUNDTOUCH_HTTP_PORT}/info"  # NOSONAR — Bose devices only support HTTP
             )
-            return resp.status_code == 200
+            if resp.status_code != 200:
+                return False, None
+            # Extract device name from XML response
+            device_name: str | None = None
+            try:
+                root = parse_xml_string(resp.content)
+                name_el = root.find("name")
+                if name_el is not None and name_el.text:
+                    device_name = name_el.text.strip()
+            except Exception:
+                logger.debug("Failed to parse device name from /info response (%s)", ip)
+            return True, device_name
         except (httpx.ConnectError, httpx.TimeoutException, httpx.ReadError):
-            return False
+            return False, None
         except Exception:
-            return False
+            return False, None
 
     async def _ssh_verify_all(self) -> None:
         """Verify BMX URL via SSH for devices with ssh_permanent=True."""

--- a/apps/backend/tests/unit/devices/test_health_check.py
+++ b/apps/backend/tests/unit/devices/test_health_check.py
@@ -103,11 +103,13 @@ class TestPingDevice:
     async def test_reachable_device_returns_true(self):
         """Device returning 200 on /info is considered reachable."""
         mock_client = AsyncMock()
-        mock_client.get.return_value = MagicMock(status_code=200)
+        mock_resp = MagicMock(status_code=200, content=b"<info><name>Living Room</name></info>")
+        mock_client.get.return_value = mock_resp
 
-        result = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
 
-        assert result is True
+        assert reachable is True
+        assert name == "Living Room"
         mock_client.get.assert_called_once_with("http://192.168.1.100:8090/info")
 
     async def test_non_200_returns_false(self):
@@ -115,27 +117,52 @@ class TestPingDevice:
         mock_client = AsyncMock()
         mock_client.get.return_value = MagicMock(status_code=500)
 
-        result = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
 
-        assert result is False
+        assert reachable is False
+        assert name is None
 
     async def test_connection_error_returns_false(self):
         """Connection error (device powered off) returns False."""
         mock_client = AsyncMock()
         mock_client.get.side_effect = httpx.ConnectError("Connection refused")
 
-        result = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
 
-        assert result is False
+        assert reachable is False
+        assert name is None
 
     async def test_timeout_returns_false(self):
         """Timeout (device unreachable) returns False."""
         mock_client = AsyncMock()
         mock_client.get.side_effect = httpx.TimeoutException("Timeout")
 
-        result = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
 
-        assert result is False
+        assert reachable is False
+        assert name is None
+
+    async def test_malformed_xml_returns_true_without_name(self):
+        """Malformed XML still reports device as reachable, name is None."""
+        mock_client = AsyncMock()
+        mock_resp = MagicMock(status_code=200, content=b"not xml at all")
+        mock_client.get.return_value = mock_resp
+
+        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+
+        assert reachable is True
+        assert name is None
+
+    async def test_xml_without_name_element(self):
+        """XML without <name> element returns None for name."""
+        mock_client = AsyncMock()
+        mock_resp = MagicMock(status_code=200, content=b"<info><type>ST300</type></info>")
+        mock_client.get.return_value = mock_resp
+
+        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+
+        assert reachable is True
+        assert name is None
 
 
 class TestPingAllDevices:
@@ -154,7 +181,7 @@ class TestPingAllDevices:
         device = _make_device(last_seen=datetime(2026, 1, 1, tzinfo=UTC))
         mock_repo.get_all.return_value = [device]
 
-        with patch.object(DeviceHealthCheck, "_ping_device", return_value=True):
+        with patch.object(DeviceHealthCheck, "_ping_device", return_value=(True, None)):
             await health_check._ping_all_devices()
 
         mock_repo.upsert.assert_called_once()
@@ -167,7 +194,7 @@ class TestPingAllDevices:
         device = _make_device(last_seen=recent)
         mock_repo.get_all.return_value = [device]
 
-        with patch.object(DeviceHealthCheck, "_ping_device", return_value=False):
+        with patch.object(DeviceHealthCheck, "_ping_device", return_value=(False, None)):
             await health_check._ping_all_devices()
 
         mock_repo.upsert.assert_not_called()
@@ -178,7 +205,7 @@ class TestPingAllDevices:
         mock_repo.get_all.return_value = [device]
 
         with patch.object(
-            DeviceHealthCheck, "_ping_device", return_value=True
+            DeviceHealthCheck, "_ping_device", return_value=(True, None)
         ) as mock_ping:
             await health_check._ping_all_devices()
 
@@ -191,13 +218,58 @@ class TestPingAllDevices:
         mock_repo.get_all.return_value = [device]
 
         with (
-            patch.object(DeviceHealthCheck, "_ping_device", return_value=False),
+            patch.object(DeviceHealthCheck, "_ping_device", return_value=(False, None)),
             patch("opencloudtouch.devices.health_check.logger") as mock_logger,
         ):
             await health_check._ping_all_devices()
 
         mock_logger.warning.assert_called_once()
         assert "offline" in mock_logger.warning.call_args[0][0].lower()
+
+    async def test_name_change_updates_device(self, health_check, mock_repo):
+        """Device name changed in Bose app gets synced to DB."""
+        device = _make_device(name="Old Name")
+        mock_repo.get_all.return_value = [device]
+
+        with patch.object(
+            DeviceHealthCheck, "_ping_device", return_value=(True, "New Name")
+        ):
+            await health_check._ping_all_devices()
+
+        mock_repo.upsert.assert_called_once()
+        updated_device = mock_repo.upsert.call_args[0][0]
+        assert updated_device.name == "New Name"
+
+    async def test_same_name_not_logged(self, health_check, mock_repo):
+        """Device with unchanged name does not trigger name change log."""
+        device = _make_device(name="Living Room")
+        mock_repo.get_all.return_value = [device]
+
+        with (
+            patch.object(
+                DeviceHealthCheck, "_ping_device", return_value=(True, "Living Room")
+            ),
+            patch("opencloudtouch.devices.health_check.logger") as mock_logger,
+        ):
+            await health_check._ping_all_devices()
+
+        # info() should not be called for name change
+        for call in mock_logger.info.call_args_list:
+            assert "name changed" not in call[0][0].lower()
+
+    async def test_none_name_preserves_existing(self, health_check, mock_repo):
+        """If device name cannot be parsed, existing name is preserved."""
+        device = _make_device(name="Original")
+        mock_repo.get_all.return_value = [device]
+
+        with patch.object(
+            DeviceHealthCheck, "_ping_device", return_value=(True, None)
+        ):
+            await health_check._ping_all_devices()
+
+        mock_repo.upsert.assert_called_once()
+        updated_device = mock_repo.upsert.call_args[0][0]
+        assert updated_device.name == "Original"
 
 
 class TestSSHVerification:

--- a/apps/backend/tests/unit/devices/test_health_check.py
+++ b/apps/backend/tests/unit/devices/test_health_check.py
@@ -103,10 +103,14 @@ class TestPingDevice:
     async def test_reachable_device_returns_true(self):
         """Device returning 200 on /info is considered reachable."""
         mock_client = AsyncMock()
-        mock_resp = MagicMock(status_code=200, content=b"<info><name>Living Room</name></info>")
+        mock_resp = MagicMock(
+            status_code=200, content=b"<info><name>Living Room</name></info>"
+        )
         mock_client.get.return_value = mock_resp
 
-        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+        reachable, name = await DeviceHealthCheck._ping_device(
+            mock_client, "192.168.1.100"
+        )
 
         assert reachable is True
         assert name == "Living Room"
@@ -117,7 +121,9 @@ class TestPingDevice:
         mock_client = AsyncMock()
         mock_client.get.return_value = MagicMock(status_code=500)
 
-        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+        reachable, name = await DeviceHealthCheck._ping_device(
+            mock_client, "192.168.1.100"
+        )
 
         assert reachable is False
         assert name is None
@@ -127,7 +133,9 @@ class TestPingDevice:
         mock_client = AsyncMock()
         mock_client.get.side_effect = httpx.ConnectError("Connection refused")
 
-        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+        reachable, name = await DeviceHealthCheck._ping_device(
+            mock_client, "192.168.1.100"
+        )
 
         assert reachable is False
         assert name is None
@@ -137,7 +145,9 @@ class TestPingDevice:
         mock_client = AsyncMock()
         mock_client.get.side_effect = httpx.TimeoutException("Timeout")
 
-        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+        reachable, name = await DeviceHealthCheck._ping_device(
+            mock_client, "192.168.1.100"
+        )
 
         assert reachable is False
         assert name is None
@@ -148,7 +158,9 @@ class TestPingDevice:
         mock_resp = MagicMock(status_code=200, content=b"not xml at all")
         mock_client.get.return_value = mock_resp
 
-        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+        reachable, name = await DeviceHealthCheck._ping_device(
+            mock_client, "192.168.1.100"
+        )
 
         assert reachable is True
         assert name is None
@@ -156,10 +168,14 @@ class TestPingDevice:
     async def test_xml_without_name_element(self):
         """XML without <name> element returns None for name."""
         mock_client = AsyncMock()
-        mock_resp = MagicMock(status_code=200, content=b"<info><type>ST300</type></info>")
+        mock_resp = MagicMock(
+            status_code=200, content=b"<info><type>ST300</type></info>"
+        )
         mock_client.get.return_value = mock_resp
 
-        reachable, name = await DeviceHealthCheck._ping_device(mock_client, "192.168.1.100")
+        reachable, name = await DeviceHealthCheck._ping_device(
+            mock_client, "192.168.1.100"
+        )
 
         assert reachable is True
         assert name is None
@@ -194,7 +210,9 @@ class TestPingAllDevices:
         device = _make_device(last_seen=recent)
         mock_repo.get_all.return_value = [device]
 
-        with patch.object(DeviceHealthCheck, "_ping_device", return_value=(False, None)):
+        with patch.object(
+            DeviceHealthCheck, "_ping_device", return_value=(False, None)
+        ):
             await health_check._ping_all_devices()
 
         mock_repo.upsert.assert_not_called()
@@ -262,9 +280,7 @@ class TestPingAllDevices:
         device = _make_device(name="Original")
         mock_repo.get_all.return_value = [device]
 
-        with patch.object(
-            DeviceHealthCheck, "_ping_device", return_value=(True, None)
-        ):
+        with patch.object(DeviceHealthCheck, "_ping_device", return_value=(True, None)):
             await health_check._ping_all_devices()
 
         mock_repo.upsert.assert_called_once()


### PR DESCRIPTION
## Problem

Device names renamed via the Bose SoundTouch app were not reflected in the OCT GUI. The health check (running every 5 minutes) only updated `last_seen` timestamps but never refreshed the device name from the actual device.

Closes #271

## Root Cause

`health_check.py::_ping_all_devices()` pinged devices to check reachability but discarded the `/info` XML response body. The device name (`<name>`) was available in every ping response but never extracted or compared against the stored name.

## Fix

- Parse the `<name>` element from the `/info` XML response during health check pings
- Compare against the stored device name in the database
- If changed, update the device record and log the change
- No additional HTTP requests needed — the name is extracted from the existing ping response

## Tests

- 4 new regression tests: name change detection, same-name no-op, null/missing name handling, malformed XML resilience
- All 31 health check tests pass
- Zero additional HTTP overhead (reuses existing ping response)
