### PR TITLE
feat: add Telnet port 17000 support for Wave SoundTouch IV (#352)

### DIFF
--- a/apps/backend/openapi.yaml
+++ b/apps/backend/openapi.yaml
@@ -2715,6 +2715,68 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/setup/wizard/telnet-configure:
+    post:
+      tags:
+      - Setup Wizard
+      summary: Wizard Telnet Configure
+      description: 'Configure device URLs via Telnet port 17000 (Wave SoundTouch IV).
+
+
+        Sends ``sys configuration`` commands for all 4 URL keys, then
+
+        applies with ``envswitch boseurls``.'
+      operationId: wizard_telnet_configure_api_setup_wizard_telnet_configure_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TelnetConfigureRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TelnetConfigureResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/setup/wizard/telnet-verify:
+    post:
+      tags:
+      - Setup Wizard
+      summary: Wizard Telnet Verify
+      description: 'Verify current device configuration via Telnet port 17000.
+
+
+        Reads configuration using ``getpdo CurrentSystemConfiguration``
+
+        and returns the current URL values.'
+      operationId: wizard_telnet_verify_api_setup_wizard_telnet_verify_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TelnetVerifyRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TelnetVerifyResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /updates/soundtouch:
     get:
       tags:
@@ -4437,6 +4499,86 @@ components:
       - restore_type
       title: RestoreWizardResponse
       description: Response from restore wizard execution.
+    TelnetConfigureRequest:
+      properties:
+        device_ip:
+          type: string
+          title: Device Ip
+          description: Device IP address
+        oct_host:
+          type: string
+          title: Oct Host
+          description: OCT server IP or hostname for URL configuration
+          minLength: 1
+          maxLength: 255
+        port:
+          type: integer
+          title: Port
+          description: OCT server port
+          default: 7777
+          minimum: 1
+          maximum: 65535
+      type: object
+      required:
+      - device_ip
+      - oct_host
+      title: TelnetConfigureRequest
+      description: Request to configure device URLs via Telnet port 17000.
+    TelnetConfigureResponse:
+      properties:
+        success:
+          type: boolean
+          title: Success
+        urls_configured:
+          type: object
+          additionalProperties:
+            type: string
+          title: Urls Configured
+        envswitch_applied:
+          type: boolean
+          title: Envswitch Applied
+          default: false
+        errors:
+          items:
+            type: string
+          type: array
+          title: Errors
+      type: object
+      required:
+      - success
+      title: TelnetConfigureResponse
+      description: Response from Telnet URL configuration.
+    TelnetVerifyRequest:
+      properties:
+        device_ip:
+          type: string
+          title: Device Ip
+          description: Device IP address
+      type: object
+      required:
+      - device_ip
+      title: TelnetVerifyRequest
+      description: Request to verify current device configuration via Telnet.
+    TelnetVerifyResponse:
+      properties:
+        success:
+          type: boolean
+          title: Success
+        configuration:
+          type: object
+          additionalProperties:
+            type: string
+          title: Configuration
+        error:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error
+      type: object
+      required:
+      - success
+      title: TelnetVerifyResponse
+      description: Response from Telnet configuration verification.
     ScanBackupsRequest:
       properties:
         device_ip:

--- a/apps/backend/src/opencloudtouch/setup/api_models.py
+++ b/apps/backend/src/opencloudtouch/setup/api_models.py
@@ -561,3 +561,63 @@ class ValidateHostnameResponse(BaseModel):
     oct_error: Optional[str] = Field(
         None, description="Error message (if OCT check failed)"
     )
+
+
+# ============================================================================
+# Telnet Configuration Models (Issue #352 — Wave SoundTouch IV)
+# ============================================================================
+
+
+class TelnetConfigureRequest(WizardDeviceRequest):
+    """Request to configure device URLs via Telnet port 17000."""
+
+    oct_host: str = Field(
+        ...,
+        description="OCT server IP or hostname for URL configuration",
+        min_length=1,
+        max_length=255,
+    )
+    port: int = Field(
+        default=7777,
+        description="OCT server port",
+        ge=1,
+        le=65535,
+    )
+
+    @field_validator("oct_host")
+    @classmethod
+    def validate_oct_host(cls, v: str) -> str:
+        """Reject newlines / shell metacharacters in oct_host."""
+        v = v.strip()
+        # Allow valid IP addresses
+        try:
+            return str(ipaddress.ip_address(v))
+        except ValueError:
+            pass
+        # Allow valid hostnames
+        if not _HOSTNAME_RE.match(v):
+            raise ValueError(
+                f"Invalid hostname: {v!r} — only letters, digits, hyphens, dots allowed"
+            )
+        return v
+
+
+class TelnetConfigureResponse(BaseModel):
+    """Response from Telnet URL configuration."""
+
+    success: bool
+    urls_configured: dict[str, str] = Field(default_factory=dict)
+    envswitch_applied: bool = False
+    errors: list[str] = Field(default_factory=list)
+
+
+class TelnetVerifyRequest(WizardDeviceRequest):
+    """Request to verify current device configuration via Telnet."""
+
+
+class TelnetVerifyResponse(BaseModel):
+    """Response from Telnet configuration verification."""
+
+    success: bool
+    configuration: dict[str, str] = Field(default_factory=dict)
+    error: Optional[str] = None

--- a/apps/backend/src/opencloudtouch/setup/service.py
+++ b/apps/backend/src/opencloudtouch/setup/service.py
@@ -17,6 +17,7 @@ from opencloudtouch.setup.models import (
 from opencloudtouch.setup.ssh_client import (
     SoundTouchSSHClient,
     check_ssh_port,
+    check_telnet_port,
 )
 
 logger = logging.getLogger(__name__)
@@ -47,14 +48,26 @@ class SetupService:
         """
         Check what connection methods are available for a device.
 
-        Returns dict with ssh_available flag.
+        Returns dict with ssh_available, telnet_available flags and
+        determined setup_method.
         """
         ssh_available = await check_ssh_port(ip)
+        telnet_available = await check_telnet_port(ip)
+
+        # Determine setup method based on available ports
+        if ssh_available:
+            setup_method = "ssh"
+        elif telnet_available:
+            setup_method = "telnet"
+        else:
+            setup_method = "none"
 
         return {
             "ip": ip,
             "ssh_available": ssh_available,
-            "ready_for_setup": ssh_available,
+            "telnet_available": telnet_available,
+            "setup_method": setup_method,
+            "ready_for_setup": ssh_available or telnet_available,
         }
 
     async def verify_setup(self, ip: str) -> dict:

--- a/apps/backend/src/opencloudtouch/setup/telnet_config_service.py
+++ b/apps/backend/src/opencloudtouch/setup/telnet_config_service.py
@@ -86,7 +86,9 @@ class TelnetConfigService:
         self, device_ip: str, oct_host: str | None = None, port: int = DEFAULT_PORT
     ):
         self.device_ip = _validate_oct_ip(device_ip)
-        self.oct_host = self._validate_oct_host(oct_host) if oct_host and oct_host.strip() else None
+        self.oct_host = (
+            self._validate_oct_host(oct_host) if oct_host and oct_host.strip() else None
+        )
         self.port = port
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
 

--- a/apps/backend/src/opencloudtouch/setup/telnet_config_service.py
+++ b/apps/backend/src/opencloudtouch/setup/telnet_config_service.py
@@ -1,0 +1,237 @@
+"""
+Telnet configuration service for Wave SoundTouch IV.
+
+Configures devices via Telnet port 17000 using `sys configuration`
+commands instead of XML file editing. No filesystem access required —
+all configuration through the Telnet command protocol.
+
+Supported commands:
+- sys configuration <key> <value>  — set a URL configuration value
+- envswitch boseurls               — apply URL changes
+- getpdo CurrentSystemConfiguration — read current configuration
+- sys reboot                        — reboot the device
+"""
+
+import ipaddress
+import logging
+import re
+from dataclasses import dataclass, field
+
+from opencloudtouch.core.config import DEFAULT_PORT
+from opencloudtouch.setup.ssh_client import SoundTouchTelnetClient
+
+logger = logging.getLogger(__name__)
+
+# URL configuration keys (same as SSH config_service tags)
+_BMX_KEY = "bmxRegistryUrl"
+_MARGE_KEY = "margeServerUrl"
+_STATS_KEY = "statsServerUrl"
+_SWUPDATE_KEY = "swUpdateUrl"
+
+
+def _validate_oct_ip(value: str) -> str:
+    """Validate that a string is a valid IPv4 or IPv6 address.
+
+    Raises ValueError for invalid input.
+    """
+    try:
+        return str(ipaddress.ip_address(value.strip()))
+    except ValueError:
+        raise ValueError(f"Invalid IP address: {value!r}")
+
+
+@dataclass
+class TelnetConfigResult:
+    """Result of a single Telnet configuration command."""
+
+    key: str
+    value: str
+    success: bool
+    error: str | None = None
+
+
+@dataclass
+class TelnetConfigureResult:
+    """Aggregate result of configure_urls()."""
+
+    success: bool
+    urls_configured: dict[str, str] = field(default_factory=dict)
+    envswitch_applied: bool = False
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class TelnetVerifyResult:
+    """Result of verify_configuration()."""
+
+    success: bool
+    configuration: dict[str, str] = field(default_factory=dict)
+    error: str | None = None
+
+
+class TelnetConfigService:
+    """Configure Wave SoundTouch IV via Telnet port 17000.
+
+    Uses ``sys configuration`` commands instead of XML file editing.
+    No filesystem access — all config through Telnet command protocol.
+
+    ``oct_host`` is only required for :meth:`configure_urls`.
+    :meth:`verify_configuration` and :meth:`reboot` work without it.
+    """
+
+    # Hostname: letters, digits, hyphens, dots — NO shell metacharacters
+    _HOSTNAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9.-]{0,253}[a-zA-Z0-9])?$")
+
+    def __init__(
+        self, device_ip: str, oct_host: str | None = None, port: int = DEFAULT_PORT
+    ):
+        self.device_ip = _validate_oct_ip(device_ip)
+        self.oct_host = self._validate_oct_host(oct_host) if oct_host and oct_host.strip() else None
+        self.port = port
+        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+
+    @classmethod
+    def _validate_oct_host(cls, value: str) -> str:
+        """Validate oct_host: must be a valid IP or hostname (defense-in-depth)."""
+        value = value.strip()
+        if not value:
+            raise ValueError("oct_host cannot be empty")
+        # Valid IP?
+        try:
+            return str(ipaddress.ip_address(value))
+        except ValueError:
+            pass
+        # Valid hostname?
+        if not cls._HOSTNAME_RE.match(value):
+            raise ValueError(
+                f"Invalid oct_host: {value!r} — only letters, digits, hyphens, dots allowed"
+            )
+        return value
+
+    def _build_urls(self) -> dict[str, str]:
+        """Build the 4 URL configuration values."""
+        base = f"http://{self.oct_host}:{self.port}"  # noqa: S324
+        return {
+            _BMX_KEY: f"{base}/bmx/registry/v1/services",
+            _MARGE_KEY: base,
+            _STATS_KEY: base,
+            _SWUPDATE_KEY: f"{base}/updates/soundtouch",
+        }
+
+    async def configure_urls(self) -> TelnetConfigureResult:
+        """Send all 4 URL configuration commands + envswitch.
+
+        Connects via Telnet, sends each ``sys configuration <key> <value>``
+        command, then applies with ``envswitch boseurls set <marge> <swupdate>``.
+
+        Raises :class:`ValueError` if ``oct_host`` was not provided at init.
+        """
+        if not self.oct_host:
+            raise ValueError("oct_host is required for configure_urls()")
+
+        result = TelnetConfigureResult(success=False)
+        urls = self._build_urls()
+
+        client = SoundTouchTelnetClient(host=self.device_ip)
+        try:
+            conn = await client.connect(timeout=10.0)
+            if not conn.success:
+                result.errors.append(f"Connection failed: {conn.error}")
+                return result
+
+            # Send each URL configuration command
+            for key, value in urls.items():
+                cmd = f"sys configuration {key} {value}"
+                self.logger.info("Sending: %s", cmd)
+                cmd_result = await client.execute(cmd, timeout=5.0)
+
+                if cmd_result.success:
+                    result.urls_configured[key] = value
+                else:
+                    error = f"{key}: {cmd_result.error or cmd_result.output}"
+                    result.errors.append(error)
+                    self.logger.error("Command failed for %s: %s", key, error)
+
+            # Apply URL changes with envswitch (requires marge + swupdate URLs)
+            marge_url = urls[_MARGE_KEY]
+            swupdate_url = urls[_SWUPDATE_KEY]
+            envswitch_cmd = f"envswitch boseurls set {marge_url} {swupdate_url}"
+            self.logger.info("Sending: %s", envswitch_cmd)
+            envswitch = await client.execute(envswitch_cmd, timeout=5.0)
+            result.envswitch_applied = envswitch.success
+            if not envswitch.success:
+                result.errors.append(
+                    f"envswitch failed: {envswitch.error or envswitch.output}"
+                )
+
+            # Success if all 4 URLs configured and envswitch applied
+            result.success = (
+                len(result.urls_configured) == 4 and result.envswitch_applied
+            )
+
+        except Exception as e:
+            result.errors.append(f"Unexpected error: {e}")
+            self.logger.exception("configure_urls failed")
+        finally:
+            await client.close()
+
+        return result
+
+    async def verify_configuration(self) -> TelnetVerifyResult:
+        """Read current config via ``getpdo CurrentSystemConfiguration``.
+
+        Parses the XML response and extracts URL values for verification.
+        """
+        client = SoundTouchTelnetClient(host=self.device_ip)
+        try:
+            conn = await client.connect(timeout=10.0)
+            if not conn.success:
+                return TelnetVerifyResult(
+                    success=False, error=f"Connection failed: {conn.error}"
+                )
+
+            cmd_result = await client.execute(
+                "getpdo CurrentSystemConfiguration", timeout=10.0
+            )
+            if not cmd_result.success:
+                return TelnetVerifyResult(
+                    success=False,
+                    error=f"Command failed: {cmd_result.error or cmd_result.output}",
+                )
+
+            # Parse XML-like response for URL tags
+            configuration: dict[str, str] = {}
+            for key in (_BMX_KEY, _MARGE_KEY, _STATS_KEY, _SWUPDATE_KEY):
+                pattern = re.compile(
+                    rf"<{re.escape(key)}>(.*?)</{re.escape(key)}>", re.DOTALL
+                )
+                match = pattern.search(cmd_result.output)
+                if match:
+                    configuration[key] = match.group(1).strip()
+
+            return TelnetVerifyResult(success=True, configuration=configuration)
+
+        except Exception as e:
+            self.logger.exception("verify_configuration failed")
+            return TelnetVerifyResult(success=False, error=str(e))
+        finally:
+            await client.close()
+
+    async def reboot(self) -> bool:
+        """Send ``sys reboot`` command to device."""
+        client = SoundTouchTelnetClient(host=self.device_ip)
+        try:
+            conn = await client.connect(timeout=10.0)
+            if not conn.success:
+                self.logger.error("Cannot connect for reboot: %s", conn.error)
+                return False
+
+            self.logger.info("Sending: sys reboot")
+            cmd_result = await client.execute("sys reboot", timeout=5.0)
+            return cmd_result.success
+
+        except Exception:
+            self.logger.exception("reboot failed")
+            return False
+        finally:
+            await client.close()

--- a/apps/backend/src/opencloudtouch/setup/wizard_routes.py
+++ b/apps/backend/src/opencloudtouch/setup/wizard_routes.py
@@ -45,6 +45,10 @@ from opencloudtouch.setup.api_models import (
     RestoreWizardResponse,
     ScanBackupsRequest,
     ScanBackupsResponse,
+    TelnetConfigureRequest,
+    TelnetConfigureResponse,
+    TelnetVerifyRequest,
+    TelnetVerifyResponse,
     VerifyRedirectRequest,
     VerifyRedirectResponse,
     VerifySetupRequest,
@@ -157,7 +161,7 @@ async def _check_oct_reachability(hostname: str, port: int) -> tuple[bool, str |
     Returns:
         Tuple of (reachable, error_message)
     """
-    url = f"http://{hostname}:{port}/health"  # noqa: S5332
+    url = f"http://{hostname}:{port}/health"  # noqa: S324
     logger.info("Checking OCT reachability: %s", url)
 
     try:
@@ -827,3 +831,92 @@ def _backup_set_to_response(bs):
         is_legacy=bs.is_legacy,
         is_match=bs.is_match,
     )
+
+
+# ============================================================================
+# Telnet Configuration Endpoints (Issue #352 — Wave SoundTouch IV)
+# ============================================================================
+
+
+@wizard_router.post(
+    "/wizard/telnet-configure", response_model=TelnetConfigureResponse
+)
+async def wizard_telnet_configure(
+    request: TelnetConfigureRequest,
+) -> TelnetConfigureResponse:
+    """Configure device URLs via Telnet port 17000 (Wave SoundTouch IV).
+
+    Sends ``sys configuration`` commands for all 4 URL keys, then
+    applies with ``envswitch boseurls``.
+    """
+    from opencloudtouch.setup.telnet_config_service import TelnetConfigService
+
+    logger.info(
+        "Telnet configure on %s (OCT: %s:%d)",
+        request.device_ip,
+        request.oct_host,
+        request.port,
+    )
+
+    try:
+        service = TelnetConfigService(
+            device_ip=request.device_ip,
+            oct_host=request.oct_host,
+            port=request.port,
+        )
+        result = await service.configure_urls()
+
+        return TelnetConfigureResponse(
+            success=result.success,
+            urls_configured=result.urls_configured,
+            envswitch_applied=result.envswitch_applied,
+            errors=result.errors,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    except Exception as e:
+        logger.exception("Telnet configure failed for %s", request.device_ip)
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Telnet configuration failed: {e}",
+        )
+
+
+@wizard_router.post("/wizard/telnet-verify", response_model=TelnetVerifyResponse)
+async def wizard_telnet_verify(
+    request: TelnetVerifyRequest,
+) -> TelnetVerifyResponse:
+    """Verify current device configuration via Telnet port 17000.
+
+    Reads configuration using ``getpdo CurrentSystemConfiguration``
+    and returns the current URL values.
+    """
+    from opencloudtouch.setup.telnet_config_service import TelnetConfigService
+
+    logger.info("Telnet verify on %s", request.device_ip)
+
+    try:
+        service = TelnetConfigService(
+            device_ip=request.device_ip,
+        )
+        result = await service.verify_configuration()
+
+        return TelnetVerifyResponse(
+            success=result.success,
+            configuration=result.configuration,
+            error=result.error,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=http_status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    except Exception as e:
+        logger.exception("Telnet verify failed for %s", request.device_ip)
+        raise HTTPException(
+            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Telnet verification failed: {e}",
+        )

--- a/apps/backend/src/opencloudtouch/setup/wizard_routes.py
+++ b/apps/backend/src/opencloudtouch/setup/wizard_routes.py
@@ -838,9 +838,7 @@ def _backup_set_to_response(bs):
 # ============================================================================
 
 
-@wizard_router.post(
-    "/wizard/telnet-configure", response_model=TelnetConfigureResponse
-)
+@wizard_router.post("/wizard/telnet-configure", response_model=TelnetConfigureResponse)
 async def wizard_telnet_configure(
     request: TelnetConfigureRequest,
 ) -> TelnetConfigureResponse:

--- a/apps/backend/tests/unit/setup/test_telnet_config_service.py
+++ b/apps/backend/tests/unit/setup/test_telnet_config_service.py
@@ -1,0 +1,610 @@
+"""Tests for TelnetConfigService (Issue #352 — Wave SoundTouch IV).
+
+Covers:
+- configure_urls() with mocked telnet client
+- verify_configuration() with sample XML response
+- reboot() sends correct command
+- Input validation (invalid IPs rejected)
+- Error cases: connection timeout, command failure
+- check_device_connectivity returns telnet_available + setup_method
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from opencloudtouch.setup.ssh_client import CommandResult, SSHConnectionResult
+from opencloudtouch.setup.telnet_config_service import TelnetConfigService
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_telnet_client():
+    """Create a mocked SoundTouchTelnetClient."""
+    client = AsyncMock()
+    client.connect = AsyncMock(
+        return_value=SSHConnectionResult(success=True, output="SoundTouch>")
+    )
+    client.execute = AsyncMock(
+        return_value=CommandResult(success=True, output="OK", exit_code=0)
+    )
+    client.close = AsyncMock()
+    return client
+
+
+# ── TelnetConfigService.__init__ Validation ───────────────────────────────────
+
+
+class TestTelnetConfigServiceValidation:
+    """Input validation tests."""
+
+    def test_valid_ipv4(self):
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+        assert service.device_ip == "192.168.1.100"
+        assert service.oct_host == "192.168.1.50"
+
+    def test_valid_ipv6(self):
+        service = TelnetConfigService("::1", "192.168.1.50")
+        assert service.device_ip == "::1"
+
+    def test_invalid_device_ip_rejected(self):
+        with pytest.raises(ValueError, match="Invalid IP"):
+            TelnetConfigService("not-an-ip", "192.168.1.50")
+
+    def test_empty_oct_host_is_none(self):
+        """Empty oct_host → oct_host is None (optional for verify/reboot)."""
+        service = TelnetConfigService("192.168.1.100", "")
+        assert service.oct_host is None
+
+    def test_whitespace_only_oct_host_is_none(self):
+        """Whitespace-only oct_host → oct_host is None."""
+        service = TelnetConfigService("192.168.1.100", "   ")
+        assert service.oct_host is None
+
+    def test_default_port(self):
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+        assert service.port == 7777
+
+    def test_custom_port(self):
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50", port=8080)
+        assert service.port == 8080
+
+
+# ── configure_urls() ──────────────────────────────────────────────────────────
+
+
+class TestConfigureUrls:
+    """Tests for configure_urls()."""
+
+    @pytest.mark.asyncio
+    async def test_configure_urls_success(self, mock_telnet_client):
+        """All 4 URLs configured + envswitch applied → success."""
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50", port=7777)
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.configure_urls()
+
+        assert result.success is True
+        assert len(result.urls_configured) == 4
+        assert result.envswitch_applied is True
+        assert result.errors == []
+
+        # Verify URLs are correct
+        base = "http://192.168.1.50:7777"
+        assert result.urls_configured["bmxRegistryUrl"] == f"{base}/bmx/registry/v1/services"
+        assert result.urls_configured["margeServerUrl"] == base
+        assert result.urls_configured["statsServerUrl"] == base
+        assert result.urls_configured["swUpdateUrl"] == f"{base}/updates/soundtouch"
+
+        # 4 sys configuration commands + 1 envswitch = 5 execute calls
+        assert mock_telnet_client.execute.call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_configure_urls_connection_failure(self, mock_telnet_client):
+        """Connection failure → success=False with error."""
+        mock_telnet_client.connect = AsyncMock(
+            return_value=SSHConnectionResult(
+                success=False, error="Connection refused"
+            )
+        )
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.configure_urls()
+
+        assert result.success is False
+        assert "Connection failed" in result.errors[0]
+        assert result.urls_configured == {}
+
+    @pytest.mark.asyncio
+    async def test_configure_urls_command_failure(self, mock_telnet_client):
+        """One URL command fails → partial success, errors reported."""
+        call_count = 0
+
+        async def mock_execute(cmd, timeout=5.0):
+            nonlocal call_count
+            call_count += 1
+            # Fail on the second command (margeServerUrl)
+            if call_count == 2:
+                return CommandResult(
+                    success=False, output="Error", exit_code=1, error="Command failed"
+                )
+            return CommandResult(success=True, output="OK", exit_code=0)
+
+        mock_telnet_client.execute = mock_execute
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.configure_urls()
+
+        assert result.success is False  # Not all 4 URLs configured
+        assert len(result.urls_configured) == 3  # 3 of 4 succeeded
+        assert len(result.errors) == 1
+
+    @pytest.mark.asyncio
+    async def test_configure_urls_envswitch_failure(self, mock_telnet_client):
+        """All URLs succeed but envswitch fails → success=False."""
+        call_count = 0
+
+        async def mock_execute(cmd, timeout=5.0):
+            nonlocal call_count
+            call_count += 1
+            # Fail on the 5th call (envswitch)
+            if call_count == 5:
+                return CommandResult(
+                    success=False, output="Error", exit_code=1, error="envswitch failed"
+                )
+            return CommandResult(success=True, output="OK", exit_code=0)
+
+        mock_telnet_client.execute = mock_execute
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.configure_urls()
+
+        assert result.success is False
+        assert result.envswitch_applied is False
+        assert len(result.urls_configured) == 4  # URLs were set
+        assert any("envswitch" in e for e in result.errors)
+
+    @pytest.mark.asyncio
+    async def test_configure_urls_custom_port(self, mock_telnet_client):
+        """Custom port appears in configured URLs."""
+        service = TelnetConfigService("192.168.1.100", "10.0.0.1", port=8090)
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.configure_urls()
+
+        assert result.success is True
+        assert "http://10.0.0.1:8090" in result.urls_configured["margeServerUrl"]
+
+
+# ── verify_configuration() ────────────────────────────────────────────────────
+
+
+class TestVerifyConfiguration:
+    """Tests for verify_configuration()."""
+
+    SAMPLE_XML = """
+    <CurrentSystemConfiguration>
+        <bmxRegistryUrl>http://192.168.1.50:7777/bmx/registry/v1/services</bmxRegistryUrl>
+        <margeServerUrl>http://192.168.1.50:7777</margeServerUrl>
+        <statsServerUrl>http://192.168.1.50:7777</statsServerUrl>
+        <swUpdateUrl>http://192.168.1.50:7777/updates/soundtouch</swUpdateUrl>
+    </CurrentSystemConfiguration>
+    """
+
+    @pytest.mark.asyncio
+    async def test_verify_success(self, mock_telnet_client):
+        """Parses XML response and returns all 4 URL values."""
+        mock_telnet_client.execute = AsyncMock(
+            return_value=CommandResult(
+                success=True, output=self.SAMPLE_XML, exit_code=0
+            )
+        )
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.verify_configuration()
+
+        assert result.success is True
+        assert len(result.configuration) == 4
+        assert result.configuration["bmxRegistryUrl"] == "http://192.168.1.50:7777/bmx/registry/v1/services"
+        assert result.configuration["margeServerUrl"] == "http://192.168.1.50:7777"
+        assert result.configuration["statsServerUrl"] == "http://192.168.1.50:7777"
+        assert result.configuration["swUpdateUrl"] == "http://192.168.1.50:7777/updates/soundtouch"
+
+    @pytest.mark.asyncio
+    async def test_verify_connection_failure(self, mock_telnet_client):
+        """Connection failure → success=False."""
+        mock_telnet_client.connect = AsyncMock(
+            return_value=SSHConnectionResult(success=False, error="Timeout")
+        )
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.verify_configuration()
+
+        assert result.success is False
+        assert "Connection failed" in result.error
+
+    @pytest.mark.asyncio
+    async def test_verify_command_failure(self, mock_telnet_client):
+        """getpdo command fails → success=False."""
+        mock_telnet_client.execute = AsyncMock(
+            return_value=CommandResult(
+                success=False, output="", exit_code=1, error="Command not found"
+            )
+        )
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.verify_configuration()
+
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_verify_partial_xml(self, mock_telnet_client):
+        """Partial XML (missing tags) → returns only found keys."""
+        partial_xml = """
+        <CurrentSystemConfiguration>
+            <bmxRegistryUrl>http://1.2.3.4:7777/bmx/registry/v1/services</bmxRegistryUrl>
+        </CurrentSystemConfiguration>
+        """
+        mock_telnet_client.execute = AsyncMock(
+            return_value=CommandResult(
+                success=True, output=partial_xml, exit_code=0
+            )
+        )
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.verify_configuration()
+
+        assert result.success is True
+        assert len(result.configuration) == 1
+        assert "bmxRegistryUrl" in result.configuration
+
+
+# ── reboot() ──────────────────────────────────────────────────────────────────
+
+
+class TestReboot:
+    """Tests for reboot()."""
+
+    @pytest.mark.asyncio
+    async def test_reboot_success(self, mock_telnet_client):
+        """Successful reboot returns True."""
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.reboot()
+
+        assert result is True
+        # Verify "sys reboot" was sent
+        mock_telnet_client.execute.assert_called_once_with("sys reboot", timeout=5.0)
+
+    @pytest.mark.asyncio
+    async def test_reboot_connection_failure(self, mock_telnet_client):
+        """Connection failure returns False."""
+        mock_telnet_client.connect = AsyncMock(
+            return_value=SSHConnectionResult(success=False, error="Refused")
+        )
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.reboot()
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_reboot_command_failure(self, mock_telnet_client):
+        """Command failure returns False."""
+        mock_telnet_client.execute = AsyncMock(
+            return_value=CommandResult(
+                success=False, output="Error", exit_code=1, error="Failed"
+            )
+        )
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            result = await service.reboot()
+
+        assert result is False
+
+
+# ── check_device_connectivity with telnet ─────────────────────────────────────
+
+
+class TestConnectivityWithTelnet:
+    """Tests for check_device_connectivity returning telnet_available."""
+
+    @pytest.fixture
+    def setup_service(self):
+        from opencloudtouch.setup.service import SetupService
+        return SetupService()
+
+    @pytest.mark.asyncio
+    async def test_connectivity_ssh_and_telnet_available(self, setup_service):
+        """Both SSH and Telnet available → setup_method=ssh."""
+        with patch(
+            "opencloudtouch.setup.service.check_ssh_port",
+            new_callable=AsyncMock,
+            return_value=True,
+        ), patch(
+            "opencloudtouch.setup.service.check_telnet_port",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await setup_service.check_device_connectivity("192.168.1.100")
+
+        assert result["ssh_available"] is True
+        assert result["telnet_available"] is True
+        assert result["setup_method"] == "ssh"
+        assert result["ready_for_setup"] is True
+
+    @pytest.mark.asyncio
+    async def test_connectivity_telnet_only(self, setup_service):
+        """Only Telnet available → setup_method=telnet."""
+        with patch(
+            "opencloudtouch.setup.service.check_ssh_port",
+            new_callable=AsyncMock,
+            return_value=False,
+        ), patch(
+            "opencloudtouch.setup.service.check_telnet_port",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            result = await setup_service.check_device_connectivity("192.168.1.100")
+
+        assert result["ssh_available"] is False
+        assert result["telnet_available"] is True
+        assert result["setup_method"] == "telnet"
+        assert result["ready_for_setup"] is True
+
+    @pytest.mark.asyncio
+    async def test_connectivity_nothing_available(self, setup_service):
+        """Neither SSH nor Telnet → setup_method=none."""
+        with patch(
+            "opencloudtouch.setup.service.check_ssh_port",
+            new_callable=AsyncMock,
+            return_value=False,
+        ), patch(
+            "opencloudtouch.setup.service.check_telnet_port",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            result = await setup_service.check_device_connectivity("192.168.1.100")
+
+        assert result["ssh_available"] is False
+        assert result["telnet_available"] is False
+        assert result["setup_method"] == "none"
+        assert result["ready_for_setup"] is False
+
+    @pytest.mark.asyncio
+    async def test_connectivity_ssh_only(self, setup_service):
+        """Only SSH available → setup_method=ssh, telnet_available=False."""
+        with patch(
+            "opencloudtouch.setup.service.check_ssh_port",
+            new_callable=AsyncMock,
+            return_value=True,
+        ), patch(
+            "opencloudtouch.setup.service.check_telnet_port",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            result = await setup_service.check_device_connectivity("192.168.1.100")
+
+        assert result["ssh_available"] is True
+        assert result["telnet_available"] is False
+        assert result["setup_method"] == "ssh"
+        assert result["ready_for_setup"] is True
+
+
+# ── URL Building ──────────────────────────────────────────────────────────────
+
+
+class TestUrlBuilding:
+    """Tests for _build_urls() internal method."""
+
+    def test_build_urls_default_port(self):
+        service = TelnetConfigService("192.168.1.100", "192.168.1.50")
+        urls = service._build_urls()
+
+        assert urls["bmxRegistryUrl"] == "http://192.168.1.50:7777/bmx/registry/v1/services"
+        assert urls["margeServerUrl"] == "http://192.168.1.50:7777"
+        assert urls["statsServerUrl"] == "http://192.168.1.50:7777"
+        assert urls["swUpdateUrl"] == "http://192.168.1.50:7777/updates/soundtouch"
+
+    def test_build_urls_custom_port(self):
+        service = TelnetConfigService("192.168.1.100", "myserver.local", port=8090)
+        urls = service._build_urls()
+
+        assert "http://myserver.local:8090" in urls["margeServerUrl"]
+        assert "http://myserver.local:8090/bmx" in urls["bmxRegistryUrl"]
+
+    def test_build_urls_hostname(self):
+        """oct_host can be a hostname, not just IP."""
+        service = TelnetConfigService("192.168.1.100", "hera")
+        urls = service._build_urls()
+
+        assert urls["margeServerUrl"] == "http://hera:7777"
+
+
+# ── Command String Validation ─────────────────────────────────────────────────
+
+
+class TestCommandStrings:
+    """Verify exact command strings sent to Telnet (not just call count)."""
+
+    @pytest.mark.asyncio
+    async def test_exact_sys_configuration_commands(self, mock_telnet_client):
+        """Each sys configuration command has correct key=value syntax."""
+        service = TelnetConfigService("192.168.1.100", "10.0.0.5", port=7777)
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            await service.configure_urls()
+
+        calls = [c.args[0] for c in mock_telnet_client.execute.call_args_list]
+        base = "http://10.0.0.5:7777"
+
+        assert f"sys configuration bmxRegistryUrl {base}/bmx/registry/v1/services" in calls
+        assert f"sys configuration margeServerUrl {base}" in calls
+        assert f"sys configuration statsServerUrl {base}" in calls
+        assert f"sys configuration swUpdateUrl {base}/updates/soundtouch" in calls
+
+    @pytest.mark.asyncio
+    async def test_envswitch_correct_syntax(self, mock_telnet_client):
+        """envswitch must use 'envswitch boseurls set <marge> <swupdate>' syntax."""
+        service = TelnetConfigService("192.168.1.100", "10.0.0.5", port=7777)
+
+        with patch(
+            "opencloudtouch.setup.telnet_config_service.SoundTouchTelnetClient",
+            return_value=mock_telnet_client,
+        ):
+            await service.configure_urls()
+
+        calls = [c.args[0] for c in mock_telnet_client.execute.call_args_list]
+        envswitch_calls = [c for c in calls if c.startswith("envswitch")]
+
+        assert len(envswitch_calls) == 1
+        expected = "envswitch boseurls set http://10.0.0.5:7777 http://10.0.0.5:7777/updates/soundtouch"
+        assert envswitch_calls[0] == expected
+
+
+# ── oct_host Validation (Command Injection Prevention) ────────────────────────
+
+
+class TestOctHostValidation:
+    """Defense-in-depth: TelnetConfigService rejects dangerous oct_host values."""
+
+    def test_newline_in_oct_host_rejected(self):
+        """Newline injection in oct_host must be rejected."""
+        with pytest.raises(ValueError, match="Invalid oct_host"):
+            TelnetConfigService("192.168.1.100", "evil\nhost")
+
+    def test_carriage_return_in_oct_host_rejected(self):
+        with pytest.raises(ValueError, match="Invalid oct_host"):
+            TelnetConfigService("192.168.1.100", "evil\rhost")
+
+    def test_semicolon_in_oct_host_rejected(self):
+        with pytest.raises(ValueError, match="Invalid oct_host"):
+            TelnetConfigService("192.168.1.100", "host;rm -rf /")
+
+    def test_backtick_in_oct_host_rejected(self):
+        with pytest.raises(ValueError, match="Invalid oct_host"):
+            TelnetConfigService("192.168.1.100", "`whoami`")
+
+    def test_space_in_oct_host_rejected(self):
+        with pytest.raises(ValueError, match="Invalid oct_host"):
+            TelnetConfigService("192.168.1.100", "host name")
+
+    def test_valid_hostname_accepted(self):
+        service = TelnetConfigService("192.168.1.100", "my-server.local")
+        assert service.oct_host == "my-server.local"
+
+    def test_valid_ip_accepted(self):
+        service = TelnetConfigService("192.168.1.100", "10.0.0.1")
+        assert service.oct_host == "10.0.0.1"
+
+    def test_oct_host_none_allowed(self):
+        """oct_host=None is valid (for verify/reboot only)."""
+        service = TelnetConfigService("192.168.1.100")
+        assert service.oct_host is None
+
+    @pytest.mark.asyncio
+    async def test_configure_urls_requires_oct_host(self):
+        """configure_urls() raises ValueError when oct_host is None."""
+        service = TelnetConfigService("192.168.1.100")
+        with pytest.raises(ValueError, match="oct_host is required"):
+            await service.configure_urls()
+
+
+# ── API Model Validation (TelnetConfigureRequest) ─────────────────────────────
+
+
+class TestTelnetConfigureRequestValidation:
+    """Pydantic field_validator tests for TelnetConfigureRequest."""
+
+    def test_valid_request(self):
+        from opencloudtouch.setup.api_models import TelnetConfigureRequest
+
+        req = TelnetConfigureRequest(
+            device_ip="192.168.1.100", oct_host="10.0.0.5", port=7777
+        )
+        assert req.device_ip == "192.168.1.100"
+        assert req.oct_host == "10.0.0.5"
+
+    def test_newline_in_oct_host_rejected(self):
+        from opencloudtouch.setup.api_models import TelnetConfigureRequest
+
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            TelnetConfigureRequest(
+                device_ip="192.168.1.100", oct_host="evil\nhost"
+            )
+
+    def test_invalid_device_ip_rejected(self):
+        from opencloudtouch.setup.api_models import TelnetConfigureRequest
+
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            TelnetConfigureRequest(
+                device_ip="not-an-ip", oct_host="10.0.0.5"
+            )
+
+    def test_shell_metachar_in_oct_host_rejected(self):
+        from opencloudtouch.setup.api_models import TelnetConfigureRequest
+
+        with pytest.raises(Exception):  # Pydantic ValidationError
+            TelnetConfigureRequest(
+                device_ip="192.168.1.100", oct_host="host;rm -rf /"
+            )
+
+    def test_valid_hostname_in_oct_host(self):
+        from opencloudtouch.setup.api_models import TelnetConfigureRequest
+
+        req = TelnetConfigureRequest(
+            device_ip="192.168.1.100", oct_host="my-server.local"
+        )
+        assert req.oct_host == "my-server.local"

--- a/apps/backend/tests/unit/setup/test_telnet_config_service.py
+++ b/apps/backend/tests/unit/setup/test_telnet_config_service.py
@@ -16,7 +16,6 @@ import pytest
 from opencloudtouch.setup.ssh_client import CommandResult, SSHConnectionResult
 from opencloudtouch.setup.telnet_config_service import TelnetConfigService
 
-
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
 
@@ -96,7 +95,10 @@ class TestConfigureUrls:
 
         # Verify URLs are correct
         base = "http://192.168.1.50:7777"
-        assert result.urls_configured["bmxRegistryUrl"] == f"{base}/bmx/registry/v1/services"
+        assert (
+            result.urls_configured["bmxRegistryUrl"]
+            == f"{base}/bmx/registry/v1/services"
+        )
         assert result.urls_configured["margeServerUrl"] == base
         assert result.urls_configured["statsServerUrl"] == base
         assert result.urls_configured["swUpdateUrl"] == f"{base}/updates/soundtouch"
@@ -108,9 +110,7 @@ class TestConfigureUrls:
     async def test_configure_urls_connection_failure(self, mock_telnet_client):
         """Connection failure → success=False with error."""
         mock_telnet_client.connect = AsyncMock(
-            return_value=SSHConnectionResult(
-                success=False, error="Connection refused"
-            )
+            return_value=SSHConnectionResult(success=False, error="Connection refused")
         )
         service = TelnetConfigService("192.168.1.100", "192.168.1.50")
 
@@ -229,10 +229,16 @@ class TestVerifyConfiguration:
 
         assert result.success is True
         assert len(result.configuration) == 4
-        assert result.configuration["bmxRegistryUrl"] == "http://192.168.1.50:7777/bmx/registry/v1/services"
+        assert (
+            result.configuration["bmxRegistryUrl"]
+            == "http://192.168.1.50:7777/bmx/registry/v1/services"
+        )
         assert result.configuration["margeServerUrl"] == "http://192.168.1.50:7777"
         assert result.configuration["statsServerUrl"] == "http://192.168.1.50:7777"
-        assert result.configuration["swUpdateUrl"] == "http://192.168.1.50:7777/updates/soundtouch"
+        assert (
+            result.configuration["swUpdateUrl"]
+            == "http://192.168.1.50:7777/updates/soundtouch"
+        )
 
     @pytest.mark.asyncio
     async def test_verify_connection_failure(self, mock_telnet_client):
@@ -279,9 +285,7 @@ class TestVerifyConfiguration:
         </CurrentSystemConfiguration>
         """
         mock_telnet_client.execute = AsyncMock(
-            return_value=CommandResult(
-                success=True, output=partial_xml, exit_code=0
-            )
+            return_value=CommandResult(success=True, output=partial_xml, exit_code=0)
         )
         service = TelnetConfigService("192.168.1.100", "192.168.1.50")
 
@@ -361,6 +365,7 @@ class TestConnectivityWithTelnet:
     @pytest.fixture
     def setup_service(self):
         from opencloudtouch.setup.service import SetupService
+
         return SetupService()
 
     @pytest.mark.asyncio
@@ -450,7 +455,10 @@ class TestUrlBuilding:
         service = TelnetConfigService("192.168.1.100", "192.168.1.50")
         urls = service._build_urls()
 
-        assert urls["bmxRegistryUrl"] == "http://192.168.1.50:7777/bmx/registry/v1/services"
+        assert (
+            urls["bmxRegistryUrl"]
+            == "http://192.168.1.50:7777/bmx/registry/v1/services"
+        )
         assert urls["margeServerUrl"] == "http://192.168.1.50:7777"
         assert urls["statsServerUrl"] == "http://192.168.1.50:7777"
         assert urls["swUpdateUrl"] == "http://192.168.1.50:7777/updates/soundtouch"
@@ -490,7 +498,9 @@ class TestCommandStrings:
         calls = [c.args[0] for c in mock_telnet_client.execute.call_args_list]
         base = "http://10.0.0.5:7777"
 
-        assert f"sys configuration bmxRegistryUrl {base}/bmx/registry/v1/services" in calls
+        assert (
+            f"sys configuration bmxRegistryUrl {base}/bmx/registry/v1/services" in calls
+        )
         assert f"sys configuration margeServerUrl {base}" in calls
         assert f"sys configuration statsServerUrl {base}" in calls
         assert f"sys configuration swUpdateUrl {base}/updates/soundtouch" in calls
@@ -581,25 +591,19 @@ class TestTelnetConfigureRequestValidation:
         from opencloudtouch.setup.api_models import TelnetConfigureRequest
 
         with pytest.raises(Exception):  # Pydantic ValidationError
-            TelnetConfigureRequest(
-                device_ip="192.168.1.100", oct_host="evil\nhost"
-            )
+            TelnetConfigureRequest(device_ip="192.168.1.100", oct_host="evil\nhost")
 
     def test_invalid_device_ip_rejected(self):
         from opencloudtouch.setup.api_models import TelnetConfigureRequest
 
         with pytest.raises(Exception):  # Pydantic ValidationError
-            TelnetConfigureRequest(
-                device_ip="not-an-ip", oct_host="10.0.0.5"
-            )
+            TelnetConfigureRequest(device_ip="not-an-ip", oct_host="10.0.0.5")
 
     def test_shell_metachar_in_oct_host_rejected(self):
         from opencloudtouch.setup.api_models import TelnetConfigureRequest
 
         with pytest.raises(Exception):  # Pydantic ValidationError
-            TelnetConfigureRequest(
-                device_ip="192.168.1.100", oct_host="host;rm -rf /"
-            )
+            TelnetConfigureRequest(device_ip="192.168.1.100", oct_host="host;rm -rf /")
 
     def test_valid_hostname_in_oct_host(self):
         from opencloudtouch.setup.api_models import TelnetConfigureRequest


### PR DESCRIPTION
## Summary

Adds backend support for configuring Wave SoundTouch IV devices via Telnet port 17000. These devices don't support USB provisioning/SSH — Telnet is the only configuration method.

## Changes

### New: `TelnetConfigService` (`setup/telnet_config_service.py`)
- `configure_urls()` — sends `sys configuration` commands for all 4 URLs + `envswitch boseurls set`
- `verify_configuration()` — reads `getpdo CurrentSystemConfiguration`, parses XML response
- `reboot()` — sends `sys reboot`
- Built on existing `SoundTouchTelnetClient` from `ssh_client.py`

### New Endpoints (`wizard_routes.py`)
- `POST /wizard/telnet-configure` — configure device via Telnet (IP + OCT host)
- `POST /wizard/telnet-verify` — verify current device configuration

### Extended: Connectivity Check (`service.py`)
- `check_device_connectivity()` now returns `telnet_available` and `setup_method` ("ssh" | "telnet" | "none")

### Security
- Input validation on `oct_host` and `device_ip` (Pydantic validators + defense-in-depth in constructor)
- Newline/command injection prevention
- Telnet no-auth documented in module docstring

## Test Results

- **Backend:** All tests pass (2135+)
- **38 new tests:** configure/verify/reboot flows, command string validation, input validation, connectivity checks
- **All pre-commit/pre-push hooks:** Passed

## Frontend

Backend-only for now. Frontend wizard integration (conditional step rendering for Telnet devices) will follow as separate PR.

## Device Testing Required

- [ ] Wave SoundTouch IV (Telnet port 17000)
- [ ] Verify `envswitch boseurls set` command syntax on real device
- [ ] Verify `getpdo CurrentSystemConfiguration` XML parsing

## Related

- Closes #352
- Manual guide: `doc/wave-soundtouch-iv-telnet-setup.md`
