### PR TITLE
fix: dissolve orphaned and unreachable zones from database (#321)

### DIFF
--- a/apps/backend/src/opencloudtouch/devices/client_adapter.py
+++ b/apps/backend/src/opencloudtouch/devices/client_adapter.py
@@ -463,13 +463,17 @@ class BoseDeviceClientAdapter(DeviceClient):
         )
 
     async def get_zone_status(self) -> ZoneStatus | None:
-        """Get current zone status from device."""
+        """Get current zone status from device.
+
+        Returns None on connection failure (expected scenario when
+        device is offline or unreachable).
+        """
         try:
             zone = await asyncio.to_thread(self._client.GetZoneStatus, refresh=True)
             return self._zone_to_status(zone)
         except Exception as e:
-            logger.exception("Failed to get zone status from %s", self.base_url)
-            raise DeviceConnectionError(self.ip, str(e)) from e
+            logger.debug("Failed to get zone status from %s: %s", self.base_url, e)
+            return None
 
     async def create_zone(
         self, master_ip: str, members: list[ZoneMemberInfo]

--- a/apps/backend/src/opencloudtouch/devices/health_check.py
+++ b/apps/backend/src/opencloudtouch/devices/health_check.py
@@ -28,6 +28,7 @@ ZONE_SYNC_INTERVAL = (
 PING_TIMEOUT = 5  # HTTP timeout per device
 OFFLINE_THRESHOLD = 15 * 60  # 15 min without response → offline
 SSH_FAIL_THRESHOLD = 2  # consecutive failures before resetting ssh_permanent
+ZONE_FAIL_THRESHOLD = 3  # consecutive failures before dissolving zone
 
 
 class DeviceHealthCheck:
@@ -41,6 +42,7 @@ class DeviceHealthCheck:
         self._last_zone_sync = 0.0
         self._running = False
         self._ssh_fail_count: dict[str, int] = {}
+        self._zone_fail_count: dict[int, int] = {}
 
     def start(self) -> None:
         """Start the background health-check loop."""
@@ -283,9 +285,18 @@ class DeviceHealthCheck:
             )
             return
 
-        if not master or not master.ip:
+        if not master:
+            logger.info(
+                "Zone sync: master %s not found in DB → dissolving zone %d",
+                zone_db.master_device_id,
+                zone_db.id,
+            )
+            await self._zone_repo.dissolve_zone(zone_db.id)
+            return
+
+        if not master.ip:
             logger.debug(
-                "Zone sync: master %s not found or offline, skipping",
+                "Zone sync: master %s has no IP, skipping (may come back)",
                 zone_db.master_device_id,
             )
             return
@@ -297,22 +308,34 @@ class DeviceHealthCheck:
             status = await client.get_zone_status()
 
             if not status:
-                logger.info(
-                    "Zone sync: master %s no longer in zone → dissolving zone %d in DB",
-                    master.device_id,
-                    zone_db.id,
-                )
-                await self._zone_repo.dissolve_zone(zone_db.id)
+                count = self._zone_fail_count.get(zone_db.id, 0) + 1
+                self._zone_fail_count[zone_db.id] = count
+                if count >= ZONE_FAIL_THRESHOLD:
+                    logger.info(
+                        "Zone sync: master %s unreachable %d times → dissolving zone %d in DB",
+                        master.device_id,
+                        count,
+                        zone_db.id,
+                    )
+                    await self._zone_repo.dissolve_zone(zone_db.id)
+                    self._zone_fail_count.pop(zone_db.id, None)
+                else:
+                    logger.debug(
+                        "Zone sync: master %s unreachable (%d/%d), will retry",
+                        master.device_id,
+                        count,
+                        ZONE_FAIL_THRESHOLD,
+                    )
                 return
 
+            self._zone_fail_count.pop(zone_db.id, None)
             await self._sync_zone_members(zone_db, status)
 
         except Exception as e:
-            logger.debug(
-                "Zone sync failed for master %s: %s",
-                master.device_id,
+            logger.exception(
+                "Zone sync unexpected error for zone %d: %s",
+                zone_db.id,
                 str(e),
-                exc_info=False,
             )
 
     async def _sync_zone_members(self, zone_db, status) -> None:

--- a/apps/backend/src/opencloudtouch/zones/service.py
+++ b/apps/backend/src/opencloudtouch/zones/service.py
@@ -78,10 +78,7 @@ class ZoneService:
         """Get zone status for a specific device."""
         device = await self._get_device_or_raise(device_id)
         client = self._get_client(device.ip)
-        try:
-            status = await client.get_zone_status()
-        except Exception as e:
-            raise DeviceConnectionError(device.ip, str(e))
+        status = await client.get_zone_status()
         if not status:
             return None
         devices = await self.device_repo.get_all()
@@ -251,11 +248,7 @@ class ZoneService:
         client = self._get_client(master.ip)
 
         # Get current zone to identify all slaves
-        try:
-            zone_status = await client.get_zone_status()
-        except Exception as e:
-            logger.error("Failed to get zone status for master_id=%s: %s", master_id, e)
-            raise DeviceConnectionError(master.ip, str(e))
+        zone_status = await client.get_zone_status()
 
         if not zone_status or not zone_status.members:
             logger.warning(
@@ -297,10 +290,7 @@ class ZoneService:
 
         # Get current zone to know members
         client = self._get_client(old_master.ip)
-        try:
-            current_zone = await client.get_zone_status()
-        except Exception as e:
-            raise DeviceConnectionError(old_master.ip, str(e))
+        current_zone = await client.get_zone_status()
 
         if not current_zone:
             raise ValueError(f"Device {old_master_id} is not in a zone")

--- a/apps/backend/tests/unit/devices/test_health_check.py
+++ b/apps/backend/tests/unit/devices/test_health_check.py
@@ -653,17 +653,17 @@ class TestZoneSyncAll:
         mock_logger.error.assert_called_once()
         assert "no ID" in mock_logger.error.call_args[0][0]
 
-    async def test_master_not_found_skips_zone(
+    async def test_master_not_found_dissolves_zone(
         self, zone_health_check, mock_repo, mock_zone_repo
     ):
-        """Master device not in DB → skip this zone."""
+        """Master device not in DB → dissolve zone."""
         zone = self._make_zone()
         mock_zone_repo.get_all_active_zones.return_value = [zone]
         mock_repo.get_by_device_id.return_value = None
 
         await zone_health_check._zone_sync_all()
 
-        mock_zone_repo.dissolve_zone.assert_not_called()
+        mock_zone_repo.dissolve_zone.assert_called_once_with(1)
 
     async def test_master_without_ip_skips_zone(
         self, zone_health_check, mock_repo, mock_zone_repo
@@ -680,7 +680,9 @@ class TestZoneSyncAll:
     async def test_device_reports_no_zone_dissolves_in_db(
         self, zone_health_check, mock_repo, mock_zone_repo
     ):
-        """Device reports no zone → dissolve_zone() is called."""
+        """Device reports no zone → dissolve_zone() called after grace period."""
+        from opencloudtouch.devices.health_check import ZONE_FAIL_THRESHOLD
+
         zone = self._make_zone(zone_id=42)
         mock_zone_repo.get_all_active_zones.return_value = [zone]
         mock_repo.get_by_device_id.return_value = _make_device()
@@ -692,7 +694,8 @@ class TestZoneSyncAll:
             "opencloudtouch.devices.adapter.get_device_client",
             return_value=mock_client,
         ):
-            await zone_health_check._zone_sync_all()
+            for _ in range(ZONE_FAIL_THRESHOLD):
+                await zone_health_check._zone_sync_all()
 
         mock_zone_repo.dissolve_zone.assert_called_once_with(42)
 
@@ -853,10 +856,10 @@ class TestZoneSyncAll:
         mock_zone_repo.add_member.assert_called_once_with(3, "dev4", "slave")
         mock_zone_repo.remove_member.assert_called_once_with(3, "dev2")
 
-    async def test_get_zone_status_exception_continues(
+    async def test_get_zone_status_exception_no_dissolve_and_continues(
         self, zone_health_check, mock_repo, mock_zone_repo
     ):
-        """Exception during get_zone_status → logged, continues to next zone."""
+        """Exception during get_zone_status → no dissolution (just logged), continues to next zone."""
         zone1 = self._make_zone(zone_id=1, master_device_id="devA")
         zone2 = self._make_zone(zone_id=2, master_device_id="devB")
         mock_zone_repo.get_all_active_zones.return_value = [zone1, zone2]
@@ -868,7 +871,7 @@ class TestZoneSyncAll:
             "devB": devB,
         }.get(did)
 
-        # First client throws, second returns no zone
+        # First client throws, second returns no zone (first failure → grace period)
         mock_client_a = AsyncMock()
         mock_client_a.get_zone_status.side_effect = Exception("Connection refused")
         mock_client_b = AsyncMock()
@@ -885,8 +888,8 @@ class TestZoneSyncAll:
         ):
             await zone_health_check._zone_sync_all()
 
-        # Zone 2 should still be dissolved despite zone 1 failing
-        mock_zone_repo.dissolve_zone.assert_called_once_with(2)
+        # Neither dissolved: zone 1 (exception → no dissolve), zone 2 (first failure → grace period)
+        mock_zone_repo.dissolve_zone.assert_not_called()
 
     async def test_outer_exception_caught_and_logged(
         self, zone_health_check, mock_zone_repo
@@ -919,6 +922,128 @@ class TestZoneSyncAll:
         mock_zone_repo.dissolve_zone.assert_not_called()
         mock_zone_repo.add_member.assert_not_called()
         mock_zone_repo.remove_member.assert_not_called()
+
+    async def test_zone_sync_grace_period_no_dissolve_first_failure(
+        self, zone_health_check, mock_repo, mock_zone_repo
+    ):
+        """First failure → no dissolution (grace period)."""
+        zone = self._make_zone(zone_id=10)
+        mock_zone_repo.get_all_active_zones.return_value = [zone]
+        mock_repo.get_by_device_id.return_value = _make_device()
+
+        mock_client = AsyncMock()
+        mock_client.get_zone_status.return_value = None
+
+        with patch(
+            "opencloudtouch.devices.adapter.get_device_client",
+            return_value=mock_client,
+        ):
+            await zone_health_check._zone_sync_all()
+
+        mock_zone_repo.dissolve_zone.assert_not_called()
+        assert zone_health_check._zone_fail_count[10] == 1
+
+    async def test_zone_sync_grace_period_dissolves_after_threshold(
+        self, zone_health_check, mock_repo, mock_zone_repo
+    ):
+        """3 consecutive failures → dissolution."""
+        from opencloudtouch.devices.health_check import ZONE_FAIL_THRESHOLD
+
+        zone = self._make_zone(zone_id=10)
+        mock_zone_repo.get_all_active_zones.return_value = [zone]
+        mock_repo.get_by_device_id.return_value = _make_device()
+
+        mock_client = AsyncMock()
+        mock_client.get_zone_status.return_value = None
+
+        with patch(
+            "opencloudtouch.devices.adapter.get_device_client",
+            return_value=mock_client,
+        ):
+            for _ in range(ZONE_FAIL_THRESHOLD):
+                mock_zone_repo.dissolve_zone.reset_mock()
+                await zone_health_check._zone_sync_all()
+
+        mock_zone_repo.dissolve_zone.assert_called_once_with(10)
+
+    async def test_zone_sync_grace_period_resets_on_success(
+        self, zone_health_check, mock_repo, mock_zone_repo
+    ):
+        """Success after 2 failures → counter reset, no dissolution."""
+        zone = self._make_zone(zone_id=10)
+        mock_zone_repo.get_all_active_zones.return_value = [zone]
+        mock_repo.get_by_device_id.return_value = _make_device()
+
+        mock_client = AsyncMock()
+        # 2 failures first
+        mock_client.get_zone_status.return_value = None
+        with patch(
+            "opencloudtouch.devices.adapter.get_device_client",
+            return_value=mock_client,
+        ):
+            await zone_health_check._zone_sync_all()
+            await zone_health_check._zone_sync_all()
+
+        assert zone_health_check._zone_fail_count[10] == 2
+
+        # Now success
+        status = self._make_zone_status()
+        mock_client.get_zone_status.return_value = status
+        mock_zone_repo.get_active_members.return_value = [
+            self._make_zone_member(zone_id=10, device_id="dev1", role="master"),
+            self._make_zone_member(zone_id=10, device_id="dev2", role="slave"),
+        ]
+        with patch(
+            "opencloudtouch.devices.adapter.get_device_client",
+            return_value=mock_client,
+        ):
+            await zone_health_check._zone_sync_all()
+
+        assert 10 not in zone_health_check._zone_fail_count
+        mock_zone_repo.dissolve_zone.assert_not_called()
+
+    async def test_zone_sync_orphan_dissolves_immediately(
+        self, zone_health_check, mock_repo, mock_zone_repo
+    ):
+        """Master device deleted from DB → immediate dissolution (no grace period)."""
+        zone = self._make_zone(zone_id=20, master_device_id="deleted_dev")
+        mock_zone_repo.get_all_active_zones.return_value = [zone]
+        mock_repo.get_by_device_id.return_value = None
+
+        await zone_health_check._zone_sync_all()
+
+        mock_zone_repo.dissolve_zone.assert_called_once_with(20)
+
+    async def test_zone_sync_master_no_ip_skips(
+        self, zone_health_check, mock_repo, mock_zone_repo
+    ):
+        """Master has no IP (may come back) → no dissolution, just skip."""
+        zone = self._make_zone(zone_id=30)
+        mock_zone_repo.get_all_active_zones.return_value = [zone]
+        mock_repo.get_by_device_id.return_value = _make_device(ip="")
+
+        await zone_health_check._zone_sync_all()
+
+        mock_zone_repo.dissolve_zone.assert_not_called()
+
+    async def test_zone_sync_unexpected_exception_no_dissolve(
+        self, zone_health_check, mock_repo, mock_zone_repo
+    ):
+        """Unexpected exception in _sync_single_zone → no dissolution, just log."""
+        zone = self._make_zone(zone_id=40)
+        mock_zone_repo.get_all_active_zones.return_value = [zone]
+        mock_repo.get_by_device_id.return_value = _make_device()
+
+        mock_client = AsyncMock()
+        mock_client.get_zone_status.side_effect = RuntimeError("Unexpected failure")
+
+        with patch(
+            "opencloudtouch.devices.adapter.get_device_client",
+            return_value=mock_client,
+        ):
+            await zone_health_check._zone_sync_all()
+
+        mock_zone_repo.dissolve_zone.assert_not_called()
 
 
 class TestHealthCheckRunLoop:

--- a/apps/backend/tests/unit/zones/test_client_adapter_zones.py
+++ b/apps/backend/tests/unit/zones/test_client_adapter_zones.py
@@ -67,13 +67,13 @@ class TestGetZoneStatus:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_raises_connection_error_on_failure(self):
-        """Raises DeviceConnectionError when client fails."""
+    async def test_returns_none_on_failure(self):
+        """Returns None when client fails (device offline)."""
         client = _make_client()
         client._client.GetZoneStatus.side_effect = Exception("Connection refused")
 
-        with pytest.raises(DeviceConnectionError):
-            await client.get_zone_status()
+        result = await client.get_zone_status()
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_members_have_correct_roles(self):

--- a/apps/backend/tests/unit/zones/test_zone_service.py
+++ b/apps/backend/tests/unit/zones/test_zone_service.py
@@ -426,20 +426,21 @@ class TestGetClientFallback:
 
 
 class TestGetZoneStatusConnectionError:
-    """Tests for get_zone_status DeviceConnectionError branch."""
+    """Tests for get_zone_status when client returns None (device offline)."""
 
     @pytest.mark.asyncio
-    async def test_raises_connection_error_on_client_exception(self):
-        """Raises DeviceConnectionError when client.get_zone_status() fails."""
+    async def test_returns_none_on_client_failure(self):
+        """Returns None when client.get_zone_status() returns None (offline device)."""
         service, device_repo, zone_repo = _make_service()
         device_repo.get_by_device_id.return_value = _make_device()
 
         mock_client = AsyncMock()
-        mock_client.get_zone_status.side_effect = Exception("Connection refused")
+        mock_client.get_zone_status.return_value = None
 
         with patch.object(service, "_get_client", return_value=mock_client):
-            with pytest.raises(DeviceConnectionError):
-                await service.get_zone_status("DEV001")
+            result = await service.get_zone_status("DEV001")
+
+        assert result is None
 
 
 class TestGetAllZonesEdgeCases:


### PR DESCRIPTION
## Summary

Fixes 3 critical bugs in zone sync dissolution logic that caused dissolved zones to accumulate in the database indefinitely. Adds a grace period mechanism to prevent false-positive dissolution during transient network issues.

## Root Cause (from Spec #350)

Zone sync polling discovers active zones on devices but never removes them from the database when zones are dissolved. Three bugs contributed:

1. **Exception Handler Bypass:** Master device unreachable → exception caught → dissolution skipped
2. **Orphaned Zones:** Master deleted from DB → early return without dissolution
3. **Contract Violation:** `get_zone_status()` raised `DeviceConnectionError` instead of returning `None`

## Changes

### Bug 3: Contract Fix (`client_adapter.py`)
- `get_zone_status()` now returns `None` on connection error (matches docstring contract)
- Log level: `exception` → `debug` (expected scenario during sync)

### Bug 2: Orphan Cleanup (`health_check.py`)
- Split `if not master or not master.ip:` into two conditions:
  - `master is None` (device deleted) → **immediate dissolution**
  - `master.ip is empty` (device offline) → skip, will retry

### Bug 1: Exception Handler (`health_check.py`)
- Exception handler now logs at `exception` level but does **NOT** dissolve
- Only device communication failures trigger grace period logic
- Unknown errors (DB, programming) are logged but don't affect zone state

### Grace Period (`health_check.py`)
- `ZONE_FAIL_THRESHOLD = 3` consecutive failures before dissolution
- Follows existing pattern: `SSH_FAIL_THRESHOLD = 2` for SSH failures
- Counter resets on successful sync
- **Exception:** Orphaned zones (master deleted) dissolve immediately — no grace period

### Caller Updates (`zones/service.py`)
- All 3 callers of `get_zone_status()` updated to handle `None` return instead of catching `DeviceConnectionError`

## Test Results

- **Backend:** 2172 passed
- **8 tests updated/added:** grace period behavior, orphan dissolution, exception handling, counter reset

## Related

- Closes #321
- Implements fixes from Spec #350
