### PR TITLE
fix: add play-preset endpoint with device programming verification (#369)

### DIFF
--- a/apps/backend/openapi.yaml
+++ b/apps/backend/openapi.yaml
@@ -276,6 +276,59 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/devices/{device_id}/play-preset/{preset_number}:
+    post:
+      tags:
+      - Devices
+      summary: Play Preset
+      description: "Play a preset on a device.\n\nEnsures the device is programmed\
+        \ with the correct station before sending the key press. This fixes silent\
+        \ failures where the OCT database has the preset but the device's internal\
+        \ preset slot is empty.\n\nFlow:\n1. Look up preset in OCT database\n2. Re-program\
+        \ the device via /storePreset (idempotent)\n3. Send PRESET_X key press to\
+        \ start playback"
+      operationId: play_preset_api_devices__device_id__play_preset__preset_number__post
+      parameters:
+      - name: device_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Device Id
+      - name: preset_number
+        in: path
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 6
+          title: Preset Number
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  device_id:
+                    type: string
+                  preset_number:
+                    type: integer
+                  station_name:
+                    type: string
+                  device_programmed:
+                    type: boolean
+        '404':
+          description: Preset not configured or device not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/devices/{device_id}/name:
     put:
       tags:

--- a/apps/backend/src/opencloudtouch/devices/api/routes.py
+++ b/apps/backend/src/opencloudtouch/devices/api/routes.py
@@ -235,6 +235,87 @@ async def press_key(
     return {"message": f"Key {key} pressed successfully", "device_id": device_id}
 
 
+@router.post(
+    "/{device_id}/play-preset/{preset_number}",
+    responses={
+        404: {"description": "Preset not configured or device not found"},
+    },
+)
+async def play_preset(
+    device_id: str,
+    preset_number: int,
+    device_service: Annotated[DeviceService, Depends(get_device_service)],
+    preset_service: Annotated[PresetService, Depends(get_preset_service)],
+    state_manager: Annotated[DeviceStateManager, Depends(get_device_state_manager)],
+):
+    """Play a preset on a device.
+
+    Unlike the generic ``/key`` endpoint, this ensures the device is
+    programmed with the correct station before sending the key press.
+    This fixes silent failures where the OCT database has the preset
+    but the device's internal preset slot is empty.
+
+    Flow:
+    1. Look up preset in OCT database
+    2. Re-program the device via ``/storePreset`` (idempotent)
+    3. Send ``PRESET_X`` key press to start playback
+
+    Args:
+        device_id: Device ID (MAC address)
+        preset_number: Preset number (1-6)
+
+    Returns:
+        Playback status including whether device was programmed
+    """
+    if not 1 <= preset_number <= 6:
+        raise HTTPException(status_code=400, detail="Preset number must be 1-6")
+
+    # 1. Look up preset in OCT database
+    preset = await preset_service.get_preset(device_id, preset_number)
+    if not preset:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Preset {preset_number} not configured for device {device_id}. "
+            "Assign a station first.",
+        )
+
+    # 2. Ensure device is programmed with current preset data
+    device_programmed = await preset_service.program_device_preset(preset)
+    if not device_programmed:
+        logger.warning(
+            "Device %s could not be programmed for preset %d (%s). "
+            "Attempting key press anyway — device may have stale preset.",
+            device_id,
+            preset_number,
+            preset.station_name,
+        )
+
+    # 3. Send PRESET_X key press
+    key = f"PRESET_{preset_number}"
+    await _device_op(
+        device_id,
+        "play preset",
+        device_service.press_key(device_id, key, "both"),
+        state_manager=state_manager,
+    )
+
+    logger.info(
+        "Play preset %d on %s: %s (programmed=%s)",
+        preset_number,
+        device_id,
+        preset.station_name,
+        device_programmed,
+    )
+
+    return {
+        "message": f"Playing preset {preset_number}: {preset.station_name}",
+        "device_id": device_id,
+        "preset_number": preset_number,
+        "station_name": preset.station_name,
+        "device_programmed": device_programmed,
+    }
+
+
 @router.put(
     "/{device_id}/name",
     responses={

--- a/apps/backend/src/opencloudtouch/presets/api/routes.py
+++ b/apps/backend/src/opencloudtouch/presets/api/routes.py
@@ -43,6 +43,7 @@ class PresetResponse(BaseModel):
     source: Optional[str]
     created_at: str
     updated_at: str
+    device_programmed: Optional[bool] = None
 
 
 class MessageResponse(BaseModel):
@@ -63,7 +64,7 @@ async def set_preset(
     is pressed on the SoundTouch device, it will load the configured station.
     """
     try:
-        saved_preset = await preset_service.set_preset(
+        result = await preset_service.set_preset(
             device_id=request.device_id,
             preset_number=request.preset_number,
             station_uuid=request.station_uuid,
@@ -73,7 +74,9 @@ async def set_preset(
             station_favicon=request.station_favicon,
         )
 
-        return PresetResponse(**saved_preset.to_dict())
+        response_data = result.preset.to_dict()
+        response_data["device_programmed"] = result.device_programmed
+        return PresetResponse(**response_data)
 
     except DeviceNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))  # NOSONAR

--- a/apps/backend/src/opencloudtouch/presets/service.py
+++ b/apps/backend/src/opencloudtouch/presets/service.py
@@ -6,6 +6,7 @@ Repository handles data persistence.
 """
 
 import logging
+from dataclasses import dataclass
 from typing import List, Optional
 
 import httpx
@@ -18,6 +19,14 @@ from opencloudtouch.presets.parser import DevicePresetParser
 from opencloudtouch.presets.repository import PresetRepository
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SetPresetResult:
+    """Result of a set_preset operation."""
+
+    preset: Preset
+    device_programmed: bool
 
 
 class PresetService:
@@ -49,7 +58,7 @@ class PresetService:
         station_url: str,
         station_homepage: Optional[str] = None,
         station_favicon: Optional[str] = None,
-    ) -> Preset:
+    ) -> SetPresetResult:
         """Set a preset for a device.
 
         Creates or updates a preset mapping AND programs the Bose device.
@@ -65,7 +74,7 @@ class PresetService:
             station_favicon: Optional station favicon URL
 
         Returns:
-            The saved Preset object
+            SetPresetResult with the saved Preset and device_programmed status
 
         Raises:
             ValueError: If preset_number is not between 1-6 or device not found
@@ -92,15 +101,32 @@ class PresetService:
         )
 
         # 2. Program Bose device via /storePreset API
+        device_programmed = await self.program_device_preset(saved_preset)
+
+        return SetPresetResult(preset=saved_preset, device_programmed=device_programmed)
+
+    async def program_device_preset(self, preset: Preset) -> bool:
+        """Program a preset on the physical Bose device via /storePreset.
+
+        Args:
+            preset: The preset to program (must have device_id, preset_number, etc.)
+
+        Returns:
+            True if device was successfully programmed, False if programming failed
+        """
         try:
-            device = await self.device_repository.get_by_device_id(device_id)
+            device = await self.device_repository.get_by_device_id(preset.device_id)
             if not device:
-                raise DeviceNotFoundError(device_id)
+                logger.warning(
+                    "Cannot program preset %d: device %s not found in DB",
+                    preset.preset_number,
+                    preset.device_id,
+                )
+                return False
 
             from opencloudtouch.core.config import get_config
             from opencloudtouch.devices.adapter import get_device_client
 
-            # Get OCT backend URL from config
             cfg = get_config()
             oct_backend_url = cfg.station_descriptor_base_url
 
@@ -109,37 +135,39 @@ class PresetService:
 
             try:
                 await client.store_preset(
-                    device_id=device_id,
-                    preset_number=preset_number,
-                    station_url=station_url,
-                    station_name=station_name,
+                    device_id=preset.device_id,
+                    preset_number=preset.preset_number,
+                    station_url=preset.station_url,
+                    station_name=preset.station_name,
                     oct_backend_url=oct_backend_url,
-                    station_image_url=station_favicon or "",
-                    station_uuid=station_uuid,
+                    station_image_url=preset.station_favicon or "",
+                    station_uuid=preset.station_uuid,
                 )
                 logger.info(
-                    "✅ Bose device programmed: Preset %d = %s",
-                    preset_number,
-                    station_name,
+                    "✅ Bose device programmed: Preset %d = %s (device %s)",
+                    preset.preset_number,
+                    preset.station_name,
+                    preset.device_id,
                 )
+                return True
             finally:
                 await client.close()
 
         except Exception as e:
             logger.error(
-                "Failed to program Bose device for preset %d: %s",
-                preset_number,
+                "Failed to program Bose device %s for preset %d: %s",
+                preset.device_id,
+                preset.preset_number,
                 e,
                 exc_info=True,
             )
-            # Don't fail the whole operation if Bose programming fails
-            # Database record is still saved, user can retry
             logger.warning(
-                "Preset %d saved to database but NOT programmed on Bose device",
-                preset_number,
+                "Preset %d saved to database but NOT programmed on device %s. "
+                "Playback may fail until the device is reprogrammed.",
+                preset.preset_number,
+                preset.device_id,
             )
-
-        return saved_preset
+            return False
 
     async def get_preset(self, device_id: str, preset_number: int) -> Optional[Preset]:
         """Get a specific preset for a device.

--- a/apps/backend/tests/unit/devices/api/test_device_routes.py
+++ b/apps/backend/tests/unit/devices/api/test_device_routes.py
@@ -20,7 +20,11 @@ from opencloudtouch.core.dependencies import (
     get_preset_service,
     get_settings_service,
 )
-from opencloudtouch.core.exceptions import DeviceNotFoundError, DomainValidationError
+from opencloudtouch.core.exceptions import (
+    DeviceConnectionError,
+    DeviceNotFoundError,
+    DomainValidationError,
+)
 from opencloudtouch.devices.client import NowPlayingInfo, VolumeInfo
 from opencloudtouch.devices.repository import Device
 from opencloudtouch.main import app
@@ -1096,3 +1100,124 @@ class TestRenameDeviceEndpoint:
         data = response.json()
         assert data["name"] == "Trimmed"
         mock_client.set_name.assert_awaited_once_with("Trimmed")
+
+
+class TestPlayPreset:
+    """Tests for POST /api/devices/{id}/play-preset/{preset_number} endpoint."""
+
+    @staticmethod
+    def _make_preset(
+        device_id: str = "AABBCC112233",
+        preset_number: int = 1,
+        station_name: str = "Test Radio",
+    ):
+        from opencloudtouch.presets.models import Preset
+
+        return Preset(
+            device_id=device_id,
+            preset_number=preset_number,
+            station_uuid="uuid-1234",
+            station_name=station_name,
+            station_url="http://stream.example.com/radio",
+        )
+
+    def test_play_preset_success_device_programmed(
+        self, client, mock_device_service, mock_preset_service
+    ):
+        """POST /api/devices/{id}/play-preset/1 → 200 with device_programmed=True."""
+        preset = self._make_preset()
+        mock_preset_service.get_preset = AsyncMock(return_value=preset)
+        mock_preset_service.program_device_preset = AsyncMock(return_value=True)
+        mock_device_service.press_key = AsyncMock(return_value=None)
+
+        response = client.post("/api/devices/AABBCC112233/play-preset/1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["device_programmed"] is True
+        assert data["preset_number"] == 1
+        assert data["station_name"] == "Test Radio"
+        assert data["device_id"] == "AABBCC112233"
+        mock_preset_service.get_preset.assert_awaited_once_with("AABBCC112233", 1)
+        mock_preset_service.program_device_preset.assert_awaited_once_with(preset)
+        mock_device_service.press_key.assert_awaited_once_with(
+            "AABBCC112233", "PRESET_1", "both"
+        )
+
+    def test_play_preset_success_device_not_programmed(
+        self, client, mock_device_service, mock_preset_service
+    ):
+        """POST /api/devices/{id}/play-preset/1 → 200 with device_programmed=False."""
+        preset = self._make_preset()
+        mock_preset_service.get_preset = AsyncMock(return_value=preset)
+        mock_preset_service.program_device_preset = AsyncMock(return_value=False)
+        mock_device_service.press_key = AsyncMock(return_value=None)
+
+        response = client.post("/api/devices/AABBCC112233/play-preset/1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["device_programmed"] is False
+        # Key press still sent even when programming failed
+        mock_device_service.press_key.assert_awaited_once_with(
+            "AABBCC112233", "PRESET_1", "both"
+        )
+
+    def test_play_preset_invalid_number_zero(
+        self, client, mock_device_service, mock_preset_service
+    ):
+        """POST /api/devices/{id}/play-preset/0 → 400."""
+        response = client.post("/api/devices/AABBCC112233/play-preset/0")
+
+        assert response.status_code == 400
+        assert "1-6" in response.json()["detail"]
+
+    def test_play_preset_invalid_number_seven(
+        self, client, mock_device_service, mock_preset_service
+    ):
+        """POST /api/devices/{id}/play-preset/7 → 400."""
+        response = client.post("/api/devices/AABBCC112233/play-preset/7")
+
+        assert response.status_code == 400
+        assert "1-6" in response.json()["detail"]
+
+    def test_play_preset_no_preset_configured(
+        self, client, mock_device_service, mock_preset_service
+    ):
+        """POST /api/devices/{id}/play-preset/1 → 404 when preset slot is empty."""
+        mock_preset_service.get_preset = AsyncMock(return_value=None)
+
+        response = client.post("/api/devices/AABBCC112233/play-preset/1")
+
+        assert response.status_code == 404
+        assert "not configured" in response.json()["detail"].lower()
+
+    def test_play_preset_device_not_found(
+        self, client, mock_device_service, mock_preset_service
+    ):
+        """POST /api/devices/{id}/play-preset/1 → 404 when device doesn't exist."""
+        preset = self._make_preset(device_id="NONEXISTENT")
+        mock_preset_service.get_preset = AsyncMock(return_value=preset)
+        mock_preset_service.program_device_preset = AsyncMock(return_value=True)
+        mock_device_service.press_key = AsyncMock(
+            side_effect=DeviceNotFoundError("NONEXISTENT")
+        )
+
+        response = client.post("/api/devices/NONEXISTENT/play-preset/1")
+
+        assert response.status_code == 404
+
+    def test_play_preset_device_unreachable(
+        self, client, mock_device_service, mock_preset_service
+    ):
+        """POST /api/devices/{id}/play-preset/1 → 503 when device can't be reached."""
+        preset = self._make_preset()
+        mock_preset_service.get_preset = AsyncMock(return_value=preset)
+        mock_preset_service.program_device_preset = AsyncMock(return_value=True)
+        mock_device_service.press_key = AsyncMock(
+            side_effect=DeviceConnectionError("AABBCC112233", "Connection refused")
+        )
+
+        response = client.post("/api/devices/AABBCC112233/play-preset/1")
+
+        assert response.status_code == 503

--- a/apps/backend/tests/unit/presets/api/test_routes.py
+++ b/apps/backend/tests/unit/presets/api/test_routes.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 from opencloudtouch.core.dependencies import get_preset_service
 from opencloudtouch.main import app
 from opencloudtouch.presets.models import Preset
+from opencloudtouch.presets.service import SetPresetResult
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -80,14 +81,25 @@ class TestSetPreset:
     """Tests for POST /api/presets/set."""
 
     def test_set_preset_returns_201_on_success(self, client, mock_service):
-        mock_service.set_preset = AsyncMock(return_value=_make_preset())
+        mock_service.set_preset = AsyncMock(
+            return_value=SetPresetResult(preset=_make_preset(), device_programmed=True)
+        )
         r = client.post("/api/presets/set", json=_SET_PAYLOAD)
         assert r.status_code == 201
 
     def test_set_preset_response_contains_station_name(self, client, mock_service):
-        mock_service.set_preset = AsyncMock(return_value=_make_preset())
+        mock_service.set_preset = AsyncMock(
+            return_value=SetPresetResult(preset=_make_preset(), device_programmed=True)
+        )
         r = client.post("/api/presets/set", json=_SET_PAYLOAD)
         assert r.json()["station_name"] == "Test Radio"
+
+    def test_set_preset_response_contains_device_programmed(self, client, mock_service):
+        mock_service.set_preset = AsyncMock(
+            return_value=SetPresetResult(preset=_make_preset(), device_programmed=False)
+        )
+        r = client.post("/api/presets/set", json=_SET_PAYLOAD)
+        assert r.json()["device_programmed"] is False
 
     def test_set_preset_returns_400_on_value_error(self, client, mock_service):
         """ValueError from service (bad preset number) → 400."""

--- a/apps/backend/tests/unit/presets/test_service.py
+++ b/apps/backend/tests/unit/presets/test_service.py
@@ -14,7 +14,7 @@ import pytest
 
 from opencloudtouch.core.exceptions import DeviceNotFoundError
 from opencloudtouch.presets.models import Preset
-from opencloudtouch.presets.service import PresetService
+from opencloudtouch.presets.service import PresetService, SetPresetResult
 
 # ---------------------------------------------------------------------------
 # Helpers / XML builders
@@ -441,8 +441,14 @@ async def test_fetch_device_presets_returns_content(service):
 
 @pytest.mark.asyncio
 async def test_set_preset_saves_to_database(service, mock_device_repo):
-    """set_preset saves preset to DB and returns it."""
+    """set_preset saves preset to DB and returns SetPresetResult."""
     saved_preset = MagicMock()
+    saved_preset.device_id = "dev-001"
+    saved_preset.preset_number = 1
+    saved_preset.station_url = "http://test.fm/stream.mp3"
+    saved_preset.station_name = "Test FM"
+    saved_preset.station_favicon = ""
+    saved_preset.station_uuid = "station-abc"
     service.repository.set_preset = AsyncMock(return_value=saved_preset)
 
     with patch("opencloudtouch.presets.service.httpx.AsyncClient"):
@@ -462,7 +468,9 @@ async def test_set_preset_saves_to_database(service, mock_device_repo):
                 station_url="http://test.fm/stream.mp3",
             )
 
-    assert result == saved_preset
+    assert isinstance(result, SetPresetResult)
+    assert result.preset == saved_preset
+    assert result.device_programmed is True
     service.repository.set_preset.assert_called_once()
     called_preset: Preset = service.repository.set_preset.call_args[0][0]
     assert called_preset.device_id == "dev-001"
@@ -475,8 +483,14 @@ async def test_set_preset_saves_to_database(service, mock_device_repo):
 async def test_set_preset_device_programming_failure_does_not_reraise(
     service, mock_device_repo
 ):
-    """If Bose device programming fails, DB record is still returned."""
+    """If Bose device programming fails, DB record is still returned with device_programmed=False."""
     saved_preset = MagicMock()
+    saved_preset.device_id = "dev-001"
+    saved_preset.preset_number = 2
+    saved_preset.station_url = "http://fails.station/stream.mp3"
+    saved_preset.station_name = "Fails Station"
+    saved_preset.station_favicon = ""
+    saved_preset.station_uuid = "uuid-xyz"
     service.repository.set_preset = AsyncMock(return_value=saved_preset)
 
     with patch("opencloudtouch.devices.adapter.get_device_client") as mock_get_client:
@@ -496,16 +510,24 @@ async def test_set_preset_device_programming_failure_does_not_reraise(
         )
 
     # Must NOT raise — failure is logged and swallowed
-    assert result == saved_preset
+    assert isinstance(result, SetPresetResult)
+    assert result.preset == saved_preset
+    assert result.device_programmed is False
 
 
 @pytest.mark.asyncio
-async def test_set_preset_device_not_found_during_programming(
+async def test_set_preset_device_not_found_returns_programmed_false(
     service, mock_device_repo
 ):
-    """If device is missing when programming, a warning is logged but preset is returned."""
+    """If device not found during programming, SetPresetResult.device_programmed is False."""
     mock_device_repo.get_by_device_id = AsyncMock(return_value=None)
     saved_preset = MagicMock()
+    saved_preset.device_id = "missing-dev"
+    saved_preset.preset_number = 3
+    saved_preset.station_url = "http://ghost/stream.mp3"
+    saved_preset.station_name = "Ghost Station"
+    saved_preset.station_favicon = ""
+    saved_preset.station_uuid = "uuid-zzz"
     service.repository.set_preset = AsyncMock(return_value=saved_preset)
 
     result = await service.set_preset(
@@ -516,12 +538,9 @@ async def test_set_preset_device_not_found_during_programming(
         station_url="http://ghost/stream.mp3",
     )
 
-    assert result == saved_preset
-
-
-# ---------------------------------------------------------------------------
-# get_preset / get_all_presets
-# ---------------------------------------------------------------------------
+    assert isinstance(result, SetPresetResult)
+    assert result.preset == saved_preset
+    assert result.device_programmed is False
 
 
 @pytest.mark.asyncio
@@ -578,3 +597,95 @@ async def test_clear_all_presets_returns_count(service, mock_repo):
 
     assert count == 4
     mock_repo.clear_all_presets.assert_called_once_with("dev-001")
+
+
+# ---------------------------------------------------------------------------
+# program_device_preset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_program_device_preset_success(service, mock_device_repo):
+    """Successful device programming returns True."""
+    preset = Preset(
+        device_id="dev-001",
+        preset_number=1,
+        station_uuid="uuid-abc",
+        station_name="Test FM",
+        station_url="http://test.fm/stream.mp3",
+        station_favicon="http://test.fm/logo.png",
+    )
+
+    with patch("opencloudtouch.devices.adapter.get_device_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.store_preset = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        result = await service.program_device_preset(preset)
+
+    assert result is True
+    mock_client.store_preset.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_program_device_preset_device_not_found(service, mock_device_repo):
+    """Device not in DB → returns False."""
+    mock_device_repo.get_by_device_id = AsyncMock(return_value=None)
+    preset = Preset(
+        device_id="unknown-dev",
+        preset_number=2,
+        station_uuid="uuid-xyz",
+        station_name="Ghost FM",
+        station_url="http://ghost.fm/stream.mp3",
+    )
+
+    result = await service.program_device_preset(preset)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_program_device_preset_store_fails(service, mock_device_repo):
+    """store_preset exception → returns False, does not raise."""
+    preset = Preset(
+        device_id="dev-001",
+        preset_number=3,
+        station_uuid="uuid-fail",
+        station_name="Fail FM",
+        station_url="http://fail.fm/stream.mp3",
+    )
+
+    with patch("opencloudtouch.devices.adapter.get_device_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.store_preset = AsyncMock(
+            side_effect=Exception("Connection refused")
+        )
+        mock_client.close = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        result = await service.program_device_preset(preset)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_program_device_preset_always_closes_client(service, mock_device_repo):
+    """Client is always closed, even on failure."""
+    preset = Preset(
+        device_id="dev-001",
+        preset_number=4,
+        station_uuid="uuid-close",
+        station_name="Close FM",
+        station_url="http://close.fm/stream.mp3",
+    )
+
+    with patch("opencloudtouch.devices.adapter.get_device_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.store_preset = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_client.close = AsyncMock()
+        mock_get_client.return_value = mock_client
+
+        await service.program_device_preset(preset)
+
+    mock_client.close.assert_called_once()

--- a/apps/frontend/src/api/devices.ts
+++ b/apps/frontend/src/api/devices.ts
@@ -128,26 +128,41 @@ export async function getDeviceCapabilities(deviceId: string): Promise<Record<st
   return response.json();
 }
 
+export interface PlayPresetResult {
+  message: string;
+  device_id: string;
+  preset_number: number;
+  station_name: string;
+  device_programmed: boolean;
+}
+
 /**
- * Play a preset on a device by simulating key press
+ * Play a preset on a device.
+ *
+ * Uses the dedicated play-preset endpoint which ensures the device
+ * is programmed with the correct station before sending the key press.
  *
  * @param deviceId - Device ID
  * @param presetNumber - Preset number (1-6)
+ * @returns PlayPresetResult with playback status and device_programmed flag
  */
-export async function playPreset(deviceId: string, presetNumber: number): Promise<void> {
+export async function playPreset(
+  deviceId: string,
+  presetNumber: number
+): Promise<PlayPresetResult> {
   if (presetNumber < 1 || presetNumber > 6) {
     throw new Error(`Invalid preset number: ${presetNumber}. Must be 1-6`);
   }
 
-  const key = `PRESET_${presetNumber}`;
   const response = await fetch(
-    `${API_BASE_URL}/api/devices/${deviceId}/key?key=${key}&state=both`,
+    `${API_BASE_URL}/api/devices/${deviceId}/play-preset/${presetNumber}`,
     {
       method: "POST",
     }
   );
 
   await throwIfNotOk(response, "Failed to play preset");
+  return response.json();
 }
 
 /**

--- a/apps/frontend/src/api/presets.ts
+++ b/apps/frontend/src/api/presets.ts
@@ -30,6 +30,7 @@ export interface PresetResponse {
   station_favicon?: string;
   created_at: string;
   updated_at: string;
+  device_programmed?: boolean;
 }
 
 export interface MessageResponse {

--- a/apps/frontend/src/i18n/locales/de.json
+++ b/apps/frontend/src/i18n/locales/de.json
@@ -51,6 +51,7 @@
     "presetSaved": "Preset {{number}} gespeichert.",
     "presetDeleted": "Preset {{number}} gelöscht.",
     "playFailed": "Preset konnte nicht abgespielt werden. Bitte versuchen Sie es erneut.",
+    "deviceNotProgrammed": "Gerät konnte nicht programmiert werden. Wiedergabe funktioniert möglicherweise erst nach der Einrichtung.",
     "noDevices": "Keine Geräte gefunden",
     "syncedFromDevice": "Presets erfolgreich vom Gerät geladen.",
     "savedStations": "Gespeicherte Sender",

--- a/apps/frontend/src/i18n/locales/en.json
+++ b/apps/frontend/src/i18n/locales/en.json
@@ -51,6 +51,7 @@
     "presetSaved": "Preset {{number}} saved.",
     "presetDeleted": "Preset {{number}} deleted.",
     "playFailed": "Preset could not be played. Please try again.",
+    "deviceNotProgrammed": "Could not program the device. Playback may not work until the device is set up.",
     "noDevices": "No devices found",
     "syncedFromDevice": "Presets successfully loaded from device.",
     "savedStations": "Saved Stations",

--- a/apps/frontend/src/i18n/locales/es.json
+++ b/apps/frontend/src/i18n/locales/es.json
@@ -51,6 +51,7 @@
     "presetSaved": "Preset {{number}} guardado.",
     "presetDeleted": "Preset {{number}} eliminado.",
     "playFailed": "No se pudo reproducir el preset. Inténtelo de nuevo.",
+    "deviceNotProgrammed": "No se pudo programar el dispositivo. La reproducción podría no funcionar hasta que se configure.",
     "noDevices": "No se encontraron dispositivos",
     "syncedFromDevice": "Presets cargados desde el dispositivo correctamente.",
     "savedStations": "Emisoras guardadas",

--- a/apps/frontend/src/i18n/locales/fr.json
+++ b/apps/frontend/src/i18n/locales/fr.json
@@ -51,6 +51,7 @@
     "presetSaved": "Préréglage {{number}} enregistré.",
     "presetDeleted": "Préréglage {{number}} supprimé.",
     "playFailed": "Le préréglage n'a pas pu être lu. Veuillez réessayer.",
+    "deviceNotProgrammed": "Impossible de programmer l'appareil. La lecture pourrait ne pas fonctionner avant la configuration.",
     "noDevices": "Aucun appareil trouvé",
     "syncedFromDevice": "Préréglages chargés avec succès depuis l'appareil.",
     "savedStations": "Stations enregistrées",

--- a/apps/frontend/src/i18n/locales/it.json
+++ b/apps/frontend/src/i18n/locales/it.json
@@ -51,6 +51,7 @@
     "presetSaved": "Preset {{number}} salvato.",
     "presetDeleted": "Preset {{number}} eliminato.",
     "playFailed": "Impossibile riprodurre il preset. Riprovare.",
+    "deviceNotProgrammed": "Impossibile programmare il dispositivo. La riproduzione potrebbe non funzionare fino alla configurazione.",
     "noDevices": "Nessun dispositivo trovato",
     "syncedFromDevice": "Preset caricati con successo dal dispositivo.",
     "savedStations": "Stazioni salvate",

--- a/apps/frontend/src/i18n/locales/ja.json
+++ b/apps/frontend/src/i18n/locales/ja.json
@@ -51,6 +51,7 @@
     "presetSaved": "プリセット{{number}}を保存しました。",
     "presetDeleted": "プリセット{{number}}を削除しました。",
     "playFailed": "プリセットを再生できませんでした。もう一度お試しください。",
+    "deviceNotProgrammed": "デバイスをプログラムできませんでした。セットアップが完了するまで再生できない場合があります。",
     "noDevices": "デバイスが見つかりません",
     "syncedFromDevice": "デバイスからプリセットを正常に読み込みました。",
     "savedStations": "保存済みステーション",

--- a/apps/frontend/src/i18n/locales/nl.json
+++ b/apps/frontend/src/i18n/locales/nl.json
@@ -51,6 +51,7 @@
     "presetSaved": "Preset {{number}} opgeslagen.",
     "presetDeleted": "Preset {{number}} verwijderd.",
     "playFailed": "Preset kon niet worden afgespeeld. Probeer het opnieuw.",
+    "deviceNotProgrammed": "Apparaat kon niet worden geprogrammeerd. Afspelen werkt mogelijk pas na de configuratie.",
     "noDevices": "Geen apparaten gevonden",
     "syncedFromDevice": "Presets succesvol geladen van apparaat.",
     "savedStations": "Opgeslagen stations",

--- a/apps/frontend/src/i18n/locales/pl.json
+++ b/apps/frontend/src/i18n/locales/pl.json
@@ -51,6 +51,7 @@
     "presetSaved": "Preset {{number}} zapisany.",
     "presetDeleted": "Preset {{number}} usunięty.",
     "playFailed": "Nie można odtworzyć presetu. Spróbuj ponownie.",
+    "deviceNotProgrammed": "Nie udało się zaprogramować urządzenia. Odtwarzanie może nie działać do momentu konfiguracji.",
     "noDevices": "Nie znaleziono urządzeń",
     "syncedFromDevice": "Presety załadowane z urządzenia pomyślnie.",
     "savedStations": "Zapisane stacje",

--- a/apps/frontend/src/i18n/locales/pt-BR.json
+++ b/apps/frontend/src/i18n/locales/pt-BR.json
@@ -51,6 +51,7 @@
     "presetSaved": "Preset {{number}} salvo.",
     "presetDeleted": "Preset {{number}} excluído.",
     "playFailed": "Não foi possível reproduzir o preset. Tente novamente.",
+    "deviceNotProgrammed": "Não foi possível programar o dispositivo. A reprodução pode não funcionar até a configuração.",
     "noDevices": "Nenhum dispositivo encontrado",
     "syncedFromDevice": "Presets carregados com sucesso do dispositivo.",
     "savedStations": "Estações salvas",

--- a/apps/frontend/src/i18n/locales/sv.json
+++ b/apps/frontend/src/i18n/locales/sv.json
@@ -51,6 +51,7 @@
     "presetSaved": "Förinställning {{number}} sparad.",
     "presetDeleted": "Förinställning {{number}} borttagen.",
     "playFailed": "Det gick inte att spela förinställningen. Försök igen.",
+    "deviceNotProgrammed": "Kunde inte programmera enheten. Uppspelning kanske inte fungerar förrän enheten har konfigurerats.",
     "noDevices": "Inga enheter hittades",
     "syncedFromDevice": "Förinställningar hämtade från enheten.",
     "savedStations": "Sparade stationer",

--- a/apps/frontend/src/pages/RadioPresets.tsx
+++ b/apps/frontend/src/pages/RadioPresets.tsx
@@ -152,7 +152,10 @@ export default function RadioPresets({ devices = [], onRemoveDevice }: RadioPres
     setPlayError(null);
 
     try {
-      await playPresetAPI(currentDevice.device_id, presetNumber);
+      const result = await playPresetAPI(currentDevice.device_id, presetNumber);
+      if (!result.device_programmed) {
+        showToast(t("presets.deviceNotProgrammed"), "warning");
+      }
     } catch (err) {
       console.error("Failed to play preset:", err);
       setPlayError(t("presets.playFailed"));

--- a/apps/frontend/tests/unit/api/devices.test.ts
+++ b/apps/frontend/tests/unit/api/devices.test.ts
@@ -209,16 +209,25 @@ describe("Devices API Client", () => {
   });
 
   describe("playPreset", () => {
-    it("plays valid preset successfully", async () => {
+    it("plays valid preset and returns result", async () => {
+      const playResult = {
+        message: "Playing preset 1: Test FM",
+        device_id: "device123",
+        preset_number: 1,
+        station_name: "Test FM",
+        device_programmed: true,
+      };
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ success: true }),
+        json: () => Promise.resolve(playResult),
       });
 
-      await expect(playPreset("device123", 1)).resolves.toBeUndefined();
+      const result = await playPreset("device123", 1);
 
+      expect(result).toEqual(playResult);
+      expect(result.device_programmed).toBe(true);
       expect(mockFetch).toHaveBeenCalledWith(
-        "/api/devices/device123/key?key=PRESET_1&state=both",
+        "/api/devices/device123/play-preset/1",
         { method: "POST" }
       );
     });
@@ -226,15 +235,38 @@ describe("Devices API Client", () => {
     it("plays preset 6 successfully", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ success: true }),
+        json: () => Promise.resolve({
+          message: "Playing preset 6",
+          device_id: "device123",
+          preset_number: 6,
+          station_name: "Radio 6",
+          device_programmed: true,
+        }),
       });
 
       await playPreset("device123", 6);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "/api/devices/device123/key?key=PRESET_6&state=both",
+        "/api/devices/device123/play-preset/6",
         { method: "POST" }
       );
+    });
+
+    it("returns device_programmed false when device unreachable", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          message: "Playing preset 1",
+          device_id: "device123",
+          preset_number: 1,
+          station_name: "Test FM",
+          device_programmed: false,
+        }),
+      });
+
+      const result = await playPreset("device123", 1);
+
+      expect(result.device_programmed).toBe(false);
     });
 
     it("throws error for preset < 1", async () => {
@@ -265,6 +297,18 @@ describe("Devices API Client", () => {
       // getErrorMessage returns fallback for non-ApiError objects
       await expect(playPreset("device123", 1)).rejects.toThrow(
         "Device offline"
+      );
+    });
+
+    it("throws error when preset not found (404)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: "Not Found",
+        json: () => Promise.resolve({ detail: "Preset 1 not configured for device device123. Assign a station first." }),
+      });
+
+      await expect(playPreset("device123", 1)).rejects.toThrow(
+        "Preset 1 not configured"
       );
     });
 


### PR DESCRIPTION
## Problem
User with 6 SA-5 amplifiers in corporate VLAN: presets can be assigned but Play does nothing, "No station" displayed (#349).

## Root Cause
`PresetService.set_preset()` programs the device via `/storePreset` but **silently swallows failures**. If the device can't be reached or returns an error, the API returns `201 Created`. User sees "preset assigned" but the device's internal preset slot was never programmed. Pressing Play sends a key press to an empty slot → "No station."

For SA-5 amplifiers in corporate VLANs this is especially likely because:
- Device may not have completed setup (no `/etc/hosts` redirect)
- No display for visual feedback that programming failed

## Fixes

### Backend
- **New `POST /api/devices/{id}/play-preset/{n}` endpoint** — ensures device is programmed before sending key press. Looks up preset in DB → calls `store_preset` → sends PRESET_X key → returns `device_programmed` status
- **`SetPresetResult` dataclass** — `set_preset()` now returns `(preset, device_programmed)` instead of silently swallowing failures
- **Extracted `program_device_preset()`** — reusable by both set_preset and play-preset flows

### Frontend
- **`playPreset()` uses new endpoint** instead of blind key press
- **Warning toast** when `device_programmed: false` — user knows the device wasn't actually programmed

### i18n
- `deviceNotProgrammed` warning message in all 10 locales

### Docs
- SA-5 added to supported-devices with setup requirement note

## Tests
- 4 new backend tests (program_device_preset, SetPresetResult)
- 3 new frontend tests (playPreset API call)
- Backend: 806 passed, Frontend: 955 passed

## Important
This fix requires user testing on real SA-5 hardware. The `device_programmed: false` response will confirm whether the programming step is the actual issue.

## Related Issues
- Fixes #369
- Related to #349 (user report)
