### PR TITLE
fix(ci): skip redundant frontend rebuilds in multi-arch Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,8 +24,8 @@ htmlcov/
 **/.vite/
 
 # Build & Test Artifacts
-# Keep .out/dist/ — pre-built frontend from CI is placed there
-# frontend-ctx/ is a named build-context override target, not part of the main context
+# Keep .out/dist/ — local `npm run build` output for self-builds
+# frontend-ctx/ is a CI-only named build-context override staging dir, not part of the main context
 frontend-ctx/
 .out/coverage/
 .out/test-results/

--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,8 @@ htmlcov/
 
 # Build & Test Artifacts
 # Keep .out/dist/ — pre-built frontend from CI is placed there
+# frontend-ctx/ is a named build-context override target, not part of the main context
+frontend-ctx/
 .out/coverage/
 .out/test-results/
 .out/reports/

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -156,10 +156,15 @@ jobs:
           AUTH=$(echo -n "$SUPPORTERS_API_USER:$SUPPORTERS_API_PASS" | base64)
           curl -H "Authorization: Basic $AUTH" \
             https://opencloudtouch.org/api/supporters/get.php \
-            -o apps/frontend/public/supporters.csv --fail --silent --show-error || {
-            echo "⚠️ Failed to fetch supporters, using empty CSV"
-            echo "name,type,amount,monthlyAmount,firstSupportDate" > apps/frontend/public/supporters.csv
+            -o apps/frontend/public/supporters.csv --fail --silent --show-error --remove-on-error || {
+            echo "⚠️ Failed to fetch supporters, keeping git-committed placeholder"
+            git checkout -- apps/frontend/public/supporters.csv
           }
+          LINES=$(wc -l < apps/frontend/public/supporters.csv)
+          if [ "$LINES" -le 1 ]; then
+            echo "::warning::Supporters fetch returned an empty list — keeping git-committed placeholder"
+            git checkout -- apps/frontend/public/supporters.csv
+          fi
           echo "✅ Supporters: $(wc -l < apps/frontend/public/supporters.csv) lines"
 
       - name: Build frontend

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -364,24 +364,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: frontend-dist
-          path: .out/dist
-
-      - name: Inject fresh supporters CSV into Docker build context
-        run: |
-          # The CI frontend build fetches supporters from the API.
-          # Copy the fresh CSV back into the source tree so the Dockerfile's
-          # frontend-build stage (COPY apps/frontend/public) picks it up.
-          if [ -f .out/dist/supporters.csv ]; then
-            LINES=$(wc -l < .out/dist/supporters.csv)
-            if [ "$LINES" -gt 1 ]; then
-              cp .out/dist/supporters.csv apps/frontend/public/supporters.csv
-              echo "✅ Fresh supporters.csv injected ($LINES lines)"
-            else
-              echo "::warning::Artifact contains empty supporters.csv ($LINES lines) — using Git version"
-            fi
-          else
-            echo "::warning::No supporters.csv in artifact — using Git version"
-          fi
+          path: frontend-ctx/build/.out/dist
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -423,6 +406,8 @@ jobs:
           push: true
           build-args: |
             OCT_BUILD_SIGNATURE=${{ steps.sign.outputs.signature }}
+          build-contexts: |
+            frontend-build=frontend-ctx
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=build-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=build-${{ matrix.platform }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -180,7 +180,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: frontend-dist
-          path: .out/dist
+          path: frontend-ctx/build/.out/dist
 
       - name: Set up QEMU
         if: matrix.platform != 'linux/amd64'
@@ -213,6 +213,8 @@ jobs:
           push: true
           build-args: |
             OCT_BUILD_SIGNATURE=${{ steps.sign.outputs.signature }}
+          build-contexts: |
+            frontend-build=frontend-ctx
           labels: |
             org.opencontainers.image.title=OpenCloudTouch
             org.opencontainers.image.description=Test build from ${{ github.ref_name }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,6 +8,9 @@
 # Docker images pushed to GHCR with the chosen tag ONLY (never "latest"/"stable").
 # Raspi images uploaded as workflow artifacts (30 day retention).
 # No version bump, no git tag, no GitHub Release.
+#
+# Set real_supporters=true to fetch the real supporters list from
+# opencloudtouch.org instead of using the placeholder CSV committed to git.
 # ==============================================================================
 
 name: Test Build
@@ -19,6 +22,11 @@ on:
         description: 'Image tag (e.g. "test", "bug-184", "feature-xyz")'
         required: true
         type: string
+      real_supporters:
+        description: 'Fetch the real supporters list from opencloudtouch.org (default: placeholder CSV from git)'
+        required: false
+        type: boolean
+        default: false
       docker_amd64:
         description: 'Docker: linux/amd64 (Desktop, Server, NAS)'
         required: false
@@ -142,6 +150,20 @@ jobs:
         run: |
           npm ci
           npm install @rollup/rollup-linux-x64-gnu --save-optional
+
+      - name: Fetch supporters from opencloudtouch.org
+        if: inputs.real_supporters == true
+        env:
+          SUPPORTERS_API_USER: oct-ci
+          SUPPORTERS_API_PASS: ${{ secrets.SUPPORTERS_API_PASS }}
+        run: |
+          AUTH=$(echo -n "$SUPPORTERS_API_USER:$SUPPORTERS_API_PASS" | base64)
+          curl -H "Authorization: Basic $AUTH" \
+            https://opencloudtouch.org/api/supporters/get.php \
+            -o apps/frontend/public/supporters.csv --fail --silent --show-error || {
+            echo "⚠️ Failed to fetch supporters, using placeholder CSV from git"
+          }
+          echo "✅ Supporters: $(wc -l < apps/frontend/public/supporters.csv) lines"
 
       - name: Build frontend
         working-directory: apps/frontend

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -157,12 +157,19 @@ jobs:
           SUPPORTERS_API_USER: oct-ci
           SUPPORTERS_API_PASS: ${{ secrets.SUPPORTERS_API_PASS }}
         run: |
+          # Fetch current supporters CSV via Basic Auth
           AUTH=$(echo -n "$SUPPORTERS_API_USER:$SUPPORTERS_API_PASS" | base64)
           curl -H "Authorization: Basic $AUTH" \
             https://opencloudtouch.org/api/supporters/get.php \
-            -o apps/frontend/public/supporters.csv --fail --silent --show-error || {
-            echo "⚠️ Failed to fetch supporters, using placeholder CSV from git"
+            -o apps/frontend/public/supporters.csv --fail --silent --show-error --remove-on-error || {
+            echo "⚠️ Failed to fetch supporters, keeping placeholder CSV from git"
+            git checkout -- apps/frontend/public/supporters.csv
           }
+          LINES=$(wc -l < apps/frontend/public/supporters.csv)
+          if [ "$LINES" -le 1 ]; then
+            echo "::warning::Supporters fetch returned an empty list — keeping placeholder CSV from git"
+            git checkout -- apps/frontend/public/supporters.csv
+          fi
           echo "✅ Supporters: $(wc -l < apps/frontend/public/supporters.csv) lines"
 
       - name: Build frontend

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -9,10 +9,13 @@
 # This allows users to clone the repo and run `docker-compose up --build`
 # without pre-building the frontend separately.
 #
-# CI pre-builds the frontend once and skips Stage 2 for all platforms via a
-# BuildKit named build-context override (`--build-context frontend-build=...`,
-# see .github/workflows/build-images.yml and test-build.yml). This is not
-# required: without that override, Stage 2 always runs for real.
+# CI pre-builds the frontend once and, in the multi-arch build-docker matrix
+# jobs, skips Stage 2 for all platforms via a BuildKit named build-context
+# override (build-contexts: frontend-build=..., see build-images.yml and
+# test-build.yml). The docker-security scan build deliberately omits the
+# override, so Stage 2 still runs there for real — this is not an oversight,
+# it keeps the self-build path exercised by CI. Without the override, Stage 2
+# always runs for real.
 #
 # Base Image Versions (Pinned for Reproducibility)
 # Update SHA256 digests with:
@@ -136,8 +139,9 @@ RUN python -m compileall -b opencloudtouch/ && \
     find opencloudtouch/ -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 # Copy frontend from build stage (built from source for self-build compatibility)
-# In CI, this stage is substituted via a BuildKit named build-context override
-# (frontend-build=<pre-built dist dir>), so it never actually runs there
+# In the build-docker matrix jobs, this stage is substituted via a BuildKit
+# named build-context override (frontend-build=<pre-built dist dir>), so it
+# never actually runs there; other CI jobs and self-builds run it for real
 COPY --from=frontend-build /build/.out/dist ./frontend/dist
 
 # Copy legal files

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -9,8 +9,10 @@
 # This allows users to clone the repo and run `docker-compose up --build`
 # without pre-building the frontend separately.
 #
-# CI may pre-build the frontend and provide it via .out/dist/ to skip Stage 2
-# for faster builds, but it's not required.
+# CI pre-builds the frontend once and skips Stage 2 for all platforms via a
+# BuildKit named build-context override (`--build-context frontend-build=...`,
+# see .github/workflows/build-images.yml and test-build.yml). This is not
+# required: without that override, Stage 2 always runs for real.
 #
 # Base Image Versions (Pinned for Reproducibility)
 # Update SHA256 digests with:
@@ -134,7 +136,8 @@ RUN python -m compileall -b opencloudtouch/ && \
     find opencloudtouch/ -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 
 # Copy frontend from build stage (built from source for self-build compatibility)
-# In CI, this stage is skipped and .out/dist is provided via build context for faster builds
+# In CI, this stage is substituted via a BuildKit named build-context override
+# (frontend-build=<pre-built dist dir>), so it never actually runs there
 COPY --from=frontend-build /build/.out/dist ./frontend/dist
 
 # Copy legal files


### PR DESCRIPTION
## Summary
- Closes #410: `build-images.yml`'s `build-docker` matrix job (amd64/arm64/arm-v7) no longer re-runs `npm ci` + `vite build` per platform — BuildKit's named build-context override (`build-contexts: frontend-build=frontend-ctx`) substitutes the Dockerfile's `frontend-build` stage with the already-built `frontend-dist` CI artifact instead, and the now-unneeded "inject fresh supporters CSV" workaround step is removed.
- Applies the same optimization to `test-build.yml`'s `build-docker` job (issue's nice-to-have).
- Adds an opt-in `real_supporters` input to `test-build.yml`, so a no-release test image can include the real, API-fetched supporters list instead of only the git-committed placeholder — requested directly alongside the issue.
- Restores a safety net that the CSV-injection step used to provide (found during final review): on a failed/empty supporters fetch, both fetch steps now fall back to the git-committed placeholder CSV instead of shipping an empty one, and use `curl --remove-on-error` to avoid leaving partial content on a mid-transfer failure.
- Corrects the Dockerfile's `frontend-build`-stage comments to describe actual behavior (the override applies only in the `build-docker` matrix jobs; `docker-security`'s scan build and local self-builds still run the stage for real, which is deliberate — it keeps that path exercised by CI).

No application code, API, or Dockerfile *functional* changes — only comment updates. `release.yml` is untouched.

## Test plan
- [x] `npm run test:unit` — 2228 backend + 953 frontend tests passing (sanity check; no app code touched by this branch)
- [x] YAML validity of both modified workflow files confirmed via `python -c "import yaml; yaml.safe_load(...)"`
- [x] Self-build regression check: confirmed locally that with no `--build-context` override, the `frontend-build` stage's real instructions (`COPY`, `npm ci`) begin executing — i.e. the self-build path is not silently skipped
- [x] Override mechanism verified empirically (twice, isolated stage + full build): staged a `frontend-ctx/build/.out/dist` directory with a marker file and ran `docker buildx build --build-context frontend-build=frontend-ctx ...` — BuildKit substitutes the stage's entire filesystem (`[context frontend-build] load from client`) with **zero** `COPY`/`RUN` instructions executed, and the nested path resolves correctly against the unmodified `COPY --from=frontend-build /build/.out/dist ./frontend/dist` instruction
- [ ] Full end-to-end multi-platform CI run — the sandbox this was built in hit an unrelated apt-get mirror stall in the `python-deps` stage that blocked a complete local image build (independent of this change; the override mechanism itself was still confirmed as above). Recommend a `workflow_dispatch` run of `test-build.yml` with `real_supporters=true` before merging, per the plan's Task 5 Step 6:
  ```
  gh workflow run test-build.yml -f image_tag=verify-410 -f real_supporters=true -f docker_amd64=true
  gh run watch
  docker pull ghcr.io/opencloudtouch/opencloudtouch:verify-410
  docker run --rm ghcr.io/opencloudtouch/opencloudtouch:verify-410 cat /app/frontend/dist/supporters.csv
  ```
  Also check the Actions log to confirm the `frontend-build` stage step shows as skipped/substituted in `build-docker`, not re-executing `npm ci`/`vite build`.
- [ ] Maintainer review of the real release pipeline change before merge (this touches `build-images.yml`, the workflow used for `latest`/`stable` tags)
