### PR TITLE
fix(setup): persist ssh_permanent flag and backfill for existing devices

### DIFF
--- a/apps/backend/src/opencloudtouch/devices/health_check.py
+++ b/apps/backend/src/opencloudtouch/devices/health_check.py
@@ -238,7 +238,12 @@ class DeviceHealthCheck:
             return False, None
 
     async def _ssh_verify_all(self) -> None:
-        """Verify BMX URL via SSH for devices with ssh_permanent=True."""
+        """Verify BMX URL via SSH for devices with ssh_permanent=True.
+
+        Configured devices that still have ssh_permanent=False (installs from
+        before enable_permanent_ssh() started persisting the flag, see #407)
+        are probed once per cycle and backfilled once SSH proves reachable.
+        """
         devices = await self._device_repo.get_all()
         config = get_config()
         our_server = (
@@ -247,8 +252,25 @@ class DeviceHealthCheck:
         )
 
         for device in devices:
-            if not device.ssh_permanent or not device.ip:
+            if not device.ip:
                 continue
+
+            if not device.ssh_permanent:
+                if device.setup_status != "configured":
+                    continue
+                if not await check_ssh_port(device.ip, timeout=3.0):
+                    continue
+                logger.info(
+                    "Backfilling ssh_permanent for %s (%s): reachable and already configured",
+                    device.name,
+                    device.ip,
+                )
+                await self._device_repo.update_setup_status(
+                    device_id=device.device_id,
+                    setup_status=device.setup_status,
+                    ssh_permanent=True,
+                )
+                device.ssh_permanent = True
 
             try:
                 await self._ssh_verify_device(device, our_server)

--- a/apps/backend/src/opencloudtouch/setup/routes.py
+++ b/apps/backend/src/opencloudtouch/setup/routes.py
@@ -11,7 +11,7 @@ from typing import Any, Dict
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi import status as http_status
 
-from opencloudtouch.core.dependencies import get_setup_service
+from opencloudtouch.core.dependencies import DeviceRepoDep, get_setup_service
 from opencloudtouch.setup.api_models import (
     ConnectivityCheckRequest,
     EnablePermanentSSHRequest,
@@ -77,6 +77,7 @@ async def get_status(
 @router.post("/ssh/enable-permanent")
 async def enable_permanent_ssh(
     request: EnablePermanentSSHRequest,
+    device_repo: DeviceRepoDep,
 ) -> Dict[str, Any]:
     """
     Enable permanent SSH access on SoundTouch device.
@@ -122,6 +123,17 @@ async def enable_permanent_ssh(
             )
 
         logger.info("Permanent SSH enabled for %s at %s", request.device_id, request.ip)
+
+        device = await device_repo.get_by_device_id(request.device_id)
+        if device is not None:
+            await device_repo.update_setup_status(
+                request.device_id, device.setup_status, ssh_permanent=True
+            )
+        else:
+            logger.warning(
+                "Cannot persist ssh_permanent for %s: device not found in DB",
+                request.device_id,
+            )
 
         return {
             "success": True,

--- a/apps/backend/tests/unit/devices/test_health_check.py
+++ b/apps/backend/tests/unit/devices/test_health_check.py
@@ -301,6 +301,61 @@ class TestSSHVerification:
 
         mock_ssh.assert_not_called()
 
+    async def test_backfills_ssh_permanent_for_configured_reachable_device(
+        self, health_check, mock_repo
+    ):
+        """A configured device without ssh_permanent=True (e.g. set up before
+        #407's fix persisted the flag) is probed and backfilled once reachable.
+        """
+        device = _make_device(
+            ssh_permanent=False, setup_status="configured", device_id="dev-backfill"
+        )
+        mock_repo.get_all.return_value = [device]
+
+        with (
+            patch(
+                "opencloudtouch.devices.health_check.check_ssh_port",
+                return_value=True,
+            ),
+            patch.object(DeviceHealthCheck, "_ssh_verify_device", AsyncMock()),
+        ):
+            await health_check._ssh_verify_all()
+
+        mock_repo.update_setup_status.assert_any_call(
+            device_id="dev-backfill", setup_status="configured", ssh_permanent=True
+        )
+
+    async def test_backfill_skipped_when_device_unreachable(
+        self, health_check, mock_repo
+    ):
+        """No backfill if the device doesn't actually respond on port 22."""
+        device = _make_device(
+            ssh_permanent=False, setup_status="configured", device_id="dev-unreach"
+        )
+        mock_repo.get_all.return_value = [device]
+
+        with patch(
+            "opencloudtouch.devices.health_check.check_ssh_port",
+            return_value=False,
+        ):
+            await health_check._ssh_verify_all()
+
+        mock_repo.update_setup_status.assert_not_called()
+
+    async def test_backfill_skipped_for_unconfigured_device(
+        self, health_check, mock_repo
+    ):
+        """Devices that never completed setup are not probed for backfill."""
+        device = _make_device(ssh_permanent=False, setup_status="unconfigured")
+        mock_repo.get_all.return_value = [device]
+
+        with patch(
+            "opencloudtouch.devices.health_check.check_ssh_port"
+        ) as mock_ssh:
+            await health_check._ssh_verify_all()
+
+        mock_ssh.assert_not_called()
+
     async def test_ssh_unreachable_skips_verification(self, health_check, mock_repo):
         """If SSH port is closed, skip further verification."""
         device = _make_device(ssh_permanent=True)

--- a/apps/backend/tests/unit/devices/test_health_check.py
+++ b/apps/backend/tests/unit/devices/test_health_check.py
@@ -349,9 +349,7 @@ class TestSSHVerification:
         device = _make_device(ssh_permanent=False, setup_status="unconfigured")
         mock_repo.get_all.return_value = [device]
 
-        with patch(
-            "opencloudtouch.devices.health_check.check_ssh_port"
-        ) as mock_ssh:
+        with patch("opencloudtouch.devices.health_check.check_ssh_port") as mock_ssh:
             await health_check._ssh_verify_all()
 
         mock_ssh.assert_not_called()

--- a/apps/backend/tests/unit/setup/test_routes.py
+++ b/apps/backend/tests/unit/setup/test_routes.py
@@ -10,7 +10,11 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from opencloudtouch.core.dependencies import get_setup_service, get_wizard_service
+from opencloudtouch.core.dependencies import (
+    get_device_repo,
+    get_setup_service,
+    get_wizard_service,
+)
 from opencloudtouch.setup import wizard_helpers
 from opencloudtouch.setup.models import (
     SetupProgress,
@@ -38,7 +42,20 @@ def mock_setup_service():
 
 
 @pytest.fixture
-def app(mock_setup_service):
+def mock_device_repo():
+    """Create mock device repository. Defaults to a known, configured device
+    so routes requiring DeviceRepoDep (e.g. /ssh/enable-permanent) work
+    out of the box for tests that don't care about persistence."""
+    repo = AsyncMock()
+    device = MagicMock()
+    device.setup_status = "configured"
+    repo.get_by_device_id = AsyncMock(return_value=device)
+    repo.update_setup_status = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def app(mock_setup_service, mock_device_repo):
     """Create test FastAPI app with setup router and mocked dependency."""
     from opencloudtouch.core.exception_handlers import register_exception_handlers
 
@@ -49,6 +66,7 @@ def app(mock_setup_service):
     # Override the dependency
     app.dependency_overrides[get_setup_service] = lambda: mock_setup_service
     app.dependency_overrides[get_wizard_service] = lambda: WizardService()
+    app.dependency_overrides[get_device_repo] = lambda: mock_device_repo
     return app
 
 
@@ -212,7 +230,9 @@ class TestEnablePermanentSSH:
     """Tests for POST /api/setup/ssh/enable-permanent."""
 
     @pytest.mark.asyncio
-    async def test_enable_permanent_ssh_success(self, client, monkeypatch):
+    async def test_enable_permanent_ssh_success(
+        self, client, monkeypatch, mock_device_repo
+    ):
         """Test enabling permanent SSH successfully."""
         # Mock SSH client
         mock_connection = AsyncMock()
@@ -257,6 +277,11 @@ class TestEnablePermanentSSH:
         mock_ssh_client.connect.assert_awaited_once()
         mock_ssh_client.execute.assert_awaited_once()
         mock_ssh_client.close.assert_awaited_once()
+
+        # #407: success must persist ssh_permanent=True, not just log it
+        mock_device_repo.update_setup_status.assert_awaited_once_with(
+            "DEVICE123", "configured", ssh_permanent=True
+        )
 
     @pytest.mark.asyncio
     async def test_enable_permanent_ssh_not_requested(self, client, monkeypatch):

--- a/apps/backend/tests/unit/setup/test_ssh_routes.py
+++ b/apps/backend/tests/unit/setup/test_ssh_routes.py
@@ -1,0 +1,85 @@
+"""Tests for setup/routes.py SSH endpoints -- Issue #407.
+
+`enable_permanent_ssh` copies remote_services to the device over SSH and
+reports success, but never persisted that outcome to the device repository.
+As a result `ssh_permanent` stayed `False` forever, which in turn made
+`health_check._ssh_verify_all()` skip the periodic SSH/BMX verification for
+every device (see devices/health_check.py).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from opencloudtouch.devices.repository import Device
+from opencloudtouch.setup.api_models import EnablePermanentSSHRequest
+from opencloudtouch.setup.routes import enable_permanent_ssh
+from opencloudtouch.setup.ssh_client import CommandResult, SSHConnectionResult
+
+
+def _make_device_repo(device: Device | None):
+    repo = AsyncMock()
+    repo.get_by_device_id = AsyncMock(return_value=device)
+    repo.update_setup_status = AsyncMock()
+    return repo
+
+
+def _make_ssh_client_cls(connect_success=True, command_success=True):
+    """Patch target for opencloudtouch.setup.routes.SoundTouchSSHClient."""
+    instance = MagicMock()
+    instance.connect = AsyncMock(
+        return_value=SSHConnectionResult(success=connect_success)
+    )
+    instance.execute = AsyncMock(
+        return_value=CommandResult(success=command_success, output="")
+    )
+    instance.close = AsyncMock()
+    cls = MagicMock(return_value=instance)
+    return cls
+
+
+@pytest.mark.asyncio
+async def test_enable_permanent_ssh_persists_flag_to_repository():
+    """A successful SSH enable must set ssh_permanent=True in the DB."""
+    device = Device(
+        device_id="ABC123",
+        ip="192.168.1.50",
+        name="Living Room",
+        model="ST10",
+        mac_address="AA:BB:CC:DD:EE:FF",
+        firmware_version="27.0.6",
+        setup_status="configured",
+        ssh_permanent=False,
+    )
+    device_repo = _make_device_repo(device)
+    request = EnablePermanentSSHRequest(
+        device_id="ABC123", ip="192.168.1.50", make_permanent=True
+    )
+
+    with patch(
+        "opencloudtouch.setup.routes.SoundTouchSSHClient",
+        _make_ssh_client_cls(),
+    ):
+        await enable_permanent_ssh(request, device_repo)
+
+    device_repo.update_setup_status.assert_awaited_once_with(
+        "ABC123", "configured", ssh_permanent=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_enable_permanent_ssh_skips_repository_update_when_device_unknown():
+    """No DB row yet must not crash the endpoint -- SSH itself still succeeded."""
+    device_repo = _make_device_repo(None)
+    request = EnablePermanentSSHRequest(
+        device_id="UNKNOWN", ip="192.168.1.51", make_permanent=True
+    )
+
+    with patch(
+        "opencloudtouch.setup.routes.SoundTouchSSHClient",
+        _make_ssh_client_cls(),
+    ):
+        result = await enable_permanent_ssh(request, device_repo)
+
+    assert result["success"] is True
+    device_repo.update_setup_status.assert_not_awaited()


### PR DESCRIPTION
## Problem

`POST /api/setup/ssh/enable-permanent` copies `remote_services` to the device over SSH and reports success, but never wrote the result back to the device repository. `ssh_permanent` stayed `false` in the database forever, regardless of how many times the wizard step succeeded.

Follow-on effect: `devices/health_check.py::_ssh_verify_all()` only runs the periodic SSH/BMX verification for devices where `ssh_permanent` is already `True`. Since it was never set, that verification cycle never ran for a single device in the field — see #407.

## Fix

- `enable_permanent_ssh()` now loads the device via `DeviceRepoDep` after a successful SSH command and persists `ssh_permanent=True`.
- `_ssh_verify_all()` backfills existing installs: a `configured` device that's still `ssh_permanent=False` (i.e. set up before this fix existed) is probed once per cycle via `check_ssh_port()`; once reachable, the flag is set and the device falls straight into the existing verification path in the same cycle.

## Tests

- New `tests/unit/setup/test_ssh_routes.py`: the endpoint persists the flag on success, and doesn't crash if the device row doesn't exist yet.
- New tests in `tests/unit/devices/test_health_check.py`: backfill fires for a reachable configured device, is skipped when unreachable, and is skipped for devices that never completed setup.
- Extended the existing `TestEnablePermanentSSH` HTTP-level test to assert the repository call.

Closes #407.