### PR TITLE
fix(devices): return cached state instead of 503 for offline devices

### DIFF
--- a/apps/backend/src/opencloudtouch/devices/api/routes.py
+++ b/apps/backend/src/opencloudtouch/devices/api/routes.py
@@ -452,12 +452,28 @@ async def get_now_playing(
     if cached and cached.now_playing and cached.is_fresh(cfg.state_cache_max_age):
         info = cached.now_playing
     else:
-        info = await _device_op(
-            device_id,
-            "get playback status",
-            device_service.get_now_playing(device_id),
-            state_manager=state_manager,
-        )
+        try:
+            info = await _device_op(
+                device_id,
+                "get playback status",
+                device_service.get_now_playing(device_id),
+                state_manager=state_manager,
+            )
+        except DeviceConnectionError:
+            # Offline devices are expected, not exceptional: return the last
+            # known state (if any) instead of a 503 that just spams the
+            # poller's browser console every cycle (#319).
+            fallback = cached.now_playing if cached else None
+            return {
+                "source": fallback.source if fallback else "",
+                "state": fallback.state if fallback else "STOP_STATE",
+                "station_name": fallback.station_name if fallback else None,
+                "artist": fallback.artist if fallback else None,
+                "track": fallback.track if fallback else None,
+                "album": fallback.album if fallback else None,
+                "artwork_url": fallback.artwork_url if fallback else None,
+                "online": False,
+            }
     result: dict[str, object] = {
         "source": info.source,
         "state": info.state,
@@ -466,6 +482,7 @@ async def get_now_playing(
         "track": info.track,
         "album": info.album,
         "artwork_url": info.artwork_url,
+        "online": True,
     }
 
     # Filter out non-image artwork URLs (e.g. station homepages)

--- a/apps/backend/src/opencloudtouch/devices/api/routes.py
+++ b/apps/backend/src/opencloudtouch/devices/api/routes.py
@@ -439,6 +439,54 @@ async def _enrich_from_presets(
     return None
 
 
+_OFFLINE_FALLBACK_INFO = NowPlayingInfo(source="", state="STOP_STATE")
+
+
+def _now_playing_to_dict(info: NowPlayingInfo, *, online: bool) -> dict[str, object]:
+    """Serialize NowPlayingInfo to the API response shape (`online` added for #319)."""
+    return {
+        "source": info.source,
+        "state": info.state,
+        "station_name": info.station_name,
+        "artist": info.artist,
+        "track": info.track,
+        "album": info.album,
+        "artwork_url": info.artwork_url,
+        "online": online,
+    }
+
+
+def _sync_enriched_state(
+    state_manager: DeviceStateManager,
+    device_id: str,
+    info: NowPlayingInfo,
+    result: dict[str, object],
+) -> None:
+    """Write enriched artist/track/artwork back to the state cache.
+
+    Keeps SSE snapshots (which read from the cache) in sync with what
+    _enrich_from_presets/_enrich_from_icy just added to *result*.
+    """
+    enriched_info = NowPlayingInfo(
+        source=info.source,
+        state=info.state,
+        station_name=info.station_name,
+        artist=str(result["artist"]) if result.get("artist") else info.artist,
+        track=str(result["track"]) if result.get("track") else info.track,
+        album=info.album,
+        artwork_url=(
+            str(result["artwork_url"])
+            if result.get("artwork_url")
+            else info.artwork_url
+        ),
+    )
+    if enriched_info.artist != info.artist or enriched_info.track != info.track:
+        state_manager.update_now_playing(device_id, enriched_info)
+        logger.debug(
+            "[NowPlaying] Wrote enriched data back to state cache for %s", device_id
+        )
+
+
 @router.get("/{device_id}/now-playing")
 async def get_now_playing(
     device_id: str,
@@ -463,27 +511,9 @@ async def get_now_playing(
             # Offline devices are expected, not exceptional: return the last
             # known state (if any) instead of a 503 that just spams the
             # poller's browser console every cycle (#319).
-            fallback = cached.now_playing if cached else None
-            return {
-                "source": fallback.source if fallback else "",
-                "state": fallback.state if fallback else "STOP_STATE",
-                "station_name": fallback.station_name if fallback else None,
-                "artist": fallback.artist if fallback else None,
-                "track": fallback.track if fallback else None,
-                "album": fallback.album if fallback else None,
-                "artwork_url": fallback.artwork_url if fallback else None,
-                "online": False,
-            }
-    result: dict[str, object] = {
-        "source": info.source,
-        "state": info.state,
-        "station_name": info.station_name,
-        "artist": info.artist,
-        "track": info.track,
-        "album": info.album,
-        "artwork_url": info.artwork_url,
-        "online": True,
-    }
+            fallback = cached.now_playing if cached else _OFFLINE_FALLBACK_INFO
+            return _now_playing_to_dict(fallback, online=False)
+    result = _now_playing_to_dict(info, online=True)
 
     # Filter out non-image artwork URLs (e.g. station homepages)
     artwork_url = result["artwork_url"]
@@ -506,26 +536,7 @@ async def get_now_playing(
             info.track,
         )
 
-    # Write enriched data back to state cache so SSE snapshots include it
-    enriched_info = NowPlayingInfo(
-        source=info.source,
-        state=info.state,
-        station_name=info.station_name,
-        artist=str(result["artist"]) if result.get("artist") else info.artist,
-        track=str(result["track"]) if result.get("track") else info.track,
-        album=info.album,
-        artwork_url=(
-            str(result["artwork_url"])
-            if result.get("artwork_url")
-            else info.artwork_url
-        ),
-    )
-    if enriched_info.artist != info.artist or enriched_info.track != info.track:
-        state_manager.update_now_playing(device_id, enriched_info)
-        logger.debug(
-            "[NowPlaying] Wrote enriched data back to state cache for %s",
-            device_id,
-        )
+    _sync_enriched_state(state_manager, device_id, info, result)
 
     logger.debug(
         "[NowPlaying] device=%s source=%s state=%s track=%r artist=%r art=%r station=%r",

--- a/apps/backend/tests/unit/devices/api/test_device_routes.py
+++ b/apps/backend/tests/unit/devices/api/test_device_routes.py
@@ -20,7 +20,11 @@ from opencloudtouch.core.dependencies import (
     get_preset_service,
     get_settings_service,
 )
-from opencloudtouch.core.exceptions import DeviceNotFoundError, DomainValidationError
+from opencloudtouch.core.exceptions import (
+    DeviceConnectionError,
+    DeviceNotFoundError,
+    DomainValidationError,
+)
 from opencloudtouch.devices.client import NowPlayingInfo, VolumeInfo
 from opencloudtouch.devices.repository import Device
 from opencloudtouch.main import app
@@ -954,6 +958,55 @@ class TestNowPlayingEndpoint:
         response = client.get("/api/devices/DEV123/now-playing")
 
         assert response.status_code == 500
+
+    def test_get_now_playing_offline_device_returns_cached_state(
+        self, client, mock_device_service
+    ):
+        """#319: an offline device must not 503 the poller -- it should get
+        the last-known now-playing info back, flagged as offline, so the UI
+        doesn't spam the browser console every poll cycle."""
+        from opencloudtouch.core.dependencies import get_device_state_manager
+
+        state_manager = client.app.dependency_overrides[get_device_state_manager]()
+        state_manager.update_now_playing(
+            "DEV123",
+            NowPlayingInfo(
+                source="INTERNET_RADIO",
+                state="PLAY_STATE",
+                station_name="Jazz FM",
+            ),
+        )
+        # Force the cached entry to be stale so the route actually re-queries
+        # the device instead of short-circuiting on the fresh-cache path.
+        state_manager.get_state("DEV123").last_update -= 999_999
+
+        mock_device_service.get_now_playing = AsyncMock(
+            side_effect=DeviceConnectionError("192.168.1.50", "Connection refused")
+        )
+
+        response = client.get("/api/devices/DEV123/now-playing")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["online"] is False
+        assert data["station_name"] == "Jazz FM"
+
+    def test_get_now_playing_offline_device_without_cache_still_returns_200(
+        self, client, mock_device_service
+    ):
+        """A device that has never reported now-playing at all must still
+        get a graceful offline response, not a 503."""
+        mock_device_service.get_now_playing = AsyncMock(
+            side_effect=DeviceConnectionError("192.168.1.60", "Connection refused")
+        )
+
+        response = client.get("/api/devices/NEVERSEEN/now-playing")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["online"] is False
+        assert data["source"] == ""
+        assert data["station_name"] is None
 
 
 class TestRenameDeviceEndpoint:

--- a/apps/backend/tests/unit/devices/test_route_cache.py
+++ b/apps/backend/tests/unit/devices/test_route_cache.py
@@ -121,6 +121,7 @@ class TestNowPlayingCacheFirst:
             "track",
             "album",
             "artwork_url",
+            "online",
         }
         assert set(data.keys()) == expected_keys
 

--- a/apps/frontend/src/api/devices.ts
+++ b/apps/frontend/src/api/devices.ts
@@ -227,6 +227,8 @@ export interface NowPlayingState {
   track?: string;
   album?: string;
   artwork_url?: string;
+  /** False when the device is unreachable; fields above are then the last known state. */
+  online?: boolean;
 }
 
 export async function getNowPlaying(deviceId: string): Promise<NowPlayingState> {


### PR DESCRIPTION
## Problem

`GET /api/devices/{id}/now-playing` lets `DeviceConnectionError` propagate to the global exception handler, which turns it into a 503. The frontend polls this endpoint periodically, so every poll cycle against a powered-off or otherwise unreachable device produces a browser console error — even though "device is offline" is expected behavior, not an exceptional one. See #319.

## Fix

- `get_now_playing()` now catches `DeviceConnectionError` and, instead of letting it 503, returns the last known now-playing info from `DeviceStateManager` (if any) plus a new `online: false` flag, with HTTP 200.
- The normal (online) response now also carries `online: true`, so the frontend can always rely on the field being present rather than inferring it from the HTTP status.
- A device that has never reported any state at all (never successfully polled once) gets an empty `source`/`station_name` with `online: false` rather than an error.
- Extended the frontend `NowPlayingState` type with the new optional `online` field.

## Tests

- New tests in `tests/unit/devices/api/test_device_routes.py`: an offline device with cached state returns 200 with the cached info and `online: false`; a device with no cache at all still returns 200 gracefully.
- Extended the existing cache-format-parity test (`test_route_cache.py::test_response_format_identical`) to include the new `online` key in the expected response shape.

Closes #319.