### PR TITLE
fix(devices): stop stream proxy on Stop, refresh UI after power toggle

### DIFF
--- a/apps/backend/src/opencloudtouch/devices/api/preset_stream_routes.py
+++ b/apps/backend/src/opencloudtouch/devices/api/preset_stream_routes.py
@@ -20,10 +20,32 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi import Path as FastAPIPath
 from fastapi.responses import Response, StreamingResponse
 
-from opencloudtouch.core.dependencies import get_preset_service
+from opencloudtouch.core.dependencies import DeviceStateManagerDep, get_preset_service
+from opencloudtouch.devices.state import DeviceStateManager
+from opencloudtouch.presets.models import Preset
 from opencloudtouch.presets.service import PresetService
 
 logger = logging.getLogger(__name__)
+
+
+def _should_keep_streaming(
+    state_manager: DeviceStateManager, device_id: str, preset: Preset
+) -> bool:
+    """False once the device's now-playing state moves away from this preset.
+
+    No cached state yet (stream just started, SSE hasn't reported back) is
+    treated as "keep going" -- we only stop once we have positive evidence
+    the device left play mode or switched to something else (#416).
+    """
+    state = state_manager.get_state(device_id)
+    if state is None or state.now_playing is None:
+        return True
+    now_playing = state.now_playing
+    if now_playing.state != "PLAY_STATE":
+        return False
+    if now_playing.station_name and now_playing.station_name != preset.station_name:
+        return False
+    return True
 
 
 def validate_stream_url(url: str) -> None:
@@ -68,6 +90,7 @@ descriptor_router = APIRouter(prefix="/descriptor/device", tags=["device-descrip
 
 @router.get("/{device_id}/preset/{preset_id}")
 async def stream_device_preset(
+    state_manager: DeviceStateManagerDep,
     device_id: str = FastAPIPath(..., description="Device identifier"),
     preset_id: int = FastAPIPath(..., ge=1, le=6, description="Preset number (1-6)"),
     preset_service: PresetService = Depends(get_preset_service),
@@ -227,6 +250,15 @@ async def stream_device_preset(
             total_bytes = 0
             try:
                 async for chunk in upstream_response.aiter_bytes(chunk_size=8192):
+                    if not _should_keep_streaming(state_manager, device_id, preset):
+                        logger.info(
+                            "[STREAM STOP] %s: device left this preset, closing proxy "
+                            "after %d chunks (%d bytes)",
+                            preset.station_name,
+                            chunks,
+                            total_bytes,
+                        )
+                        break
                     chunks += 1
                     total_bytes += len(chunk)
                     yield chunk

--- a/apps/backend/tests/integration/conftest.py
+++ b/apps/backend/tests/integration/conftest.py
@@ -16,6 +16,7 @@ from opencloudtouch.db import DeviceRepository
 from opencloudtouch.devices.adapter import BoseDeviceDiscoveryAdapter
 from opencloudtouch.devices.service import DeviceService
 from opencloudtouch.devices.services.sync_service import DeviceSyncService
+from opencloudtouch.devices.state import DeviceStateManager
 from opencloudtouch.settings.repository import SettingsRepository
 from opencloudtouch.settings.service import SettingsService
 
@@ -153,6 +154,7 @@ async def real_api_client(real_db):
     test_app.state.device_service = device_service
     test_app.state.settings_service = settings_service
     test_app.state.preset_service = preset_service
+    test_app.state.device_state_manager = DeviceStateManager()
 
     transport = ASGITransport(app=test_app)
     timeout = Timeout(5.0, connect=2.0)  # 5s read, 2s connect - prevent hangs

--- a/apps/backend/tests/unit/devices/api/test_preset_stream_routes.py
+++ b/apps/backend/tests/unit/devices/api/test_preset_stream_routes.py
@@ -10,7 +10,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from opencloudtouch.core.dependencies import get_preset_service
+from opencloudtouch.core.dependencies import get_device_state_manager, get_preset_service
+from opencloudtouch.devices.client import NowPlayingInfo
+from opencloudtouch.devices.state import DeviceStateManager
 from opencloudtouch.main import app
 from opencloudtouch.presets.models import Preset
 
@@ -22,9 +24,16 @@ def mock_preset_service():
 
 
 @pytest.fixture
-def client(mock_preset_service):
-    """TestClient with preset service dependency override."""
+def state_manager():
+    """Real DeviceStateManager so tests can simulate now-playing transitions."""
+    return DeviceStateManager()
+
+
+@pytest.fixture
+def client(mock_preset_service, state_manager):
+    """TestClient with preset service + device state manager dependency overrides."""
     app.dependency_overrides[get_preset_service] = lambda: mock_preset_service
+    app.dependency_overrides[get_device_state_manager] = lambda: state_manager
     yield TestClient(app)
     app.dependency_overrides.clear()
 
@@ -82,6 +91,55 @@ class TestStreamDevicePreset:
             with client.stream("GET", "/device/689E194F7D2F/preset/1") as response:
                 assert response.status_code == 200
                 assert "audio" in response.headers.get("content-type", "")
+
+    def test_stream_stops_when_device_no_longer_playing(
+        self, client, mock_preset_service, sample_preset, state_manager
+    ):
+        """#416: once the device's now-playing state moves away from this
+        preset (e.g. the user pressed Stop), the proxy must stop pulling
+        from upstream instead of forwarding bytes forever."""
+        mock_preset_service.get_preset = AsyncMock(return_value=sample_preset)
+        device_id = sample_preset.device_id
+        state_manager.update_now_playing(
+            device_id,
+            NowPlayingInfo(
+                source="INTERNET_RADIO",
+                state="PLAY_STATE",
+                station_name=sample_preset.station_name,
+            ),
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "audio/mpeg"}
+        mock_response.aclose = AsyncMock()
+
+        async def mock_aiter_bytes(chunk_size=8192):
+            yield b"chunk_1"
+            # Simulate the user pressing Stop mid-stream.
+            state_manager.update_now_playing(
+                device_id, NowPlayingInfo(source="STANDBY", state="STOP_STATE")
+            )
+            yield b"chunk_2"
+
+        mock_response.aiter_bytes = mock_aiter_bytes
+
+        mock_http_client = MagicMock()
+        mock_http_client.send = AsyncMock(return_value=mock_response)
+        mock_http_client.aclose = AsyncMock()
+
+        with patch(
+            "opencloudtouch.devices.api.preset_stream_routes.httpx.AsyncClient",
+            return_value=mock_http_client,
+        ), patch(
+            "opencloudtouch.devices.api.preset_stream_routes.validate_stream_url",
+        ):
+            with client.stream("GET", f"/device/{device_id}/preset/1") as response:
+                body = b"".join(response.iter_bytes())
+
+        assert body == b"chunk_1"
+        mock_response.aclose.assert_awaited_once()
+        mock_http_client.aclose.assert_awaited_once()
 
     def test_upstream_non_200_raises_502(
         self, client, mock_preset_service, sample_preset

--- a/apps/backend/tests/unit/devices/api/test_preset_stream_routes.py
+++ b/apps/backend/tests/unit/devices/api/test_preset_stream_routes.py
@@ -10,7 +10,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from opencloudtouch.core.dependencies import get_device_state_manager, get_preset_service
+from opencloudtouch.core.dependencies import (
+    get_device_state_manager,
+    get_preset_service,
+)
 from opencloudtouch.devices.client import NowPlayingInfo
 from opencloudtouch.devices.state import DeviceStateManager
 from opencloudtouch.main import app

--- a/apps/frontend/src/pages/RadioPresets.tsx
+++ b/apps/frontend/src/pages/RadioPresets.tsx
@@ -43,7 +43,9 @@ export default function RadioPresets({ devices = [], onRemoveDevice }: RadioPres
   const { presets, loading, syncing, error, clearError, syncPresets, assignStation, removePreset } =
     usePresets(currentDevice?.device_id);
   const { volume, muted, setDeviceVolume, toggleMute } = useVolume(currentDevice?.device_id);
-  const { nowPlaying: npState } = useNowPlaying(currentDevice?.device_id);
+  const { nowPlaying: npState, refresh: refreshNowPlaying } = useNowPlaying(
+    currentDevice?.device_id
+  );
   const { show: showToast } = useToast();
   const [playError, setPlayError] = useState<string | null>(null);
   const [powerLoading, setPowerLoading] = useState(false);
@@ -201,6 +203,10 @@ export default function RadioPresets({ devices = [], onRemoveDevice }: RadioPres
                   setPowerLoading(true);
                   try {
                     await power(currentDevice.device_id);
+                    // Device SSE push for the resulting state change can be
+                    // delayed or missed -- force a fetch so the button and
+                    // NowPlaying view don't get stuck showing stale state (#416).
+                    await refreshNowPlaying();
                   } catch (err) {
                     console.error("[RadioPresets] Power failed:", err);
                   } finally {
@@ -263,6 +269,7 @@ export default function RadioPresets({ devices = [], onRemoveDevice }: RadioPres
                   ? async () => {
                       if (isStandby) {
                         await power(currentDevice.device_id);
+                        await refreshNowPlaying();
                       } else {
                         await togglePlayPause(currentDevice.device_id);
                       }

--- a/apps/frontend/tests/unit/RadioPresets.test.tsx
+++ b/apps/frontend/tests/unit/RadioPresets.test.tsx
@@ -39,8 +39,14 @@ vi.mock("../../src/hooks/useVolume", () => ({
   useVolume: () => mockVolumeState,
 }));
 
+const mockRefreshNowPlaying = vi.fn();
 vi.mock("../../src/hooks/useNowPlaying", () => ({
-  useNowPlaying: () => ({ nowPlaying: null, loading: false, error: null, refresh: vi.fn() }),
+  useNowPlaying: () => ({
+    nowPlaying: null,
+    loading: false,
+    error: null,
+    refresh: mockRefreshNowPlaying,
+  }),
 }));
 
 import * as presetsApi from "../../src/api/presets";
@@ -307,6 +313,27 @@ describe("RadioPresets Page", () => {
       // Both presets should be assigned
       expect(screen.getByTestId("preset-1-name")).toBeInTheDocument();
       expect(screen.getByTestId("preset-2-name")).toBeInTheDocument();
+    });
+  });
+
+  describe("Power Button", () => {
+    it("refreshes now-playing state after toggling power (#416)", async () => {
+      await act(async () => {
+        render(<RadioPresets devices={mockDevices} />);
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText("Power on/off"));
+      });
+
+      // The device's own SSE push can be delayed or missed entirely, so the
+      // power button must force a fresh fetch itself instead of only
+      // trusting the push channel -- otherwise the UI is stuck showing the
+      // pre-toggle state until something else (e.g. a tab switch) happens
+      // to remount the hook.
+      await waitFor(() => {
+        expect(mockRefreshNowPlaying).toHaveBeenCalled();
+      });
     });
   });
 


### PR DESCRIPTION
## Problem

Two related bugs reported in the same thread on #416:

**A) Stream proxy keeps running after Stop.** `preset_stream_routes.py`'s `stream_generator()` never checked the device's actual playback state -- it forwarded bytes from the upstream HTTPS stream until the device itself closed the TCP connection, which some devices don't do promptly on Stop. Reporter confirmed via Proxmox network graphs that "Incoming" traffic continued after pressing Stop in the UI.

**B) Presets page UI doesn't refresh after power toggle.** The power button calls the device API but never refreshes local state afterward, relying entirely on the device's own SSE push. When that push is delayed or missed, the button and `NowPlaying` view get stuck showing the pre-toggle state until something unrelated (switching to another tab and back) happens to remount the hook and force a fresh fetch.

## Fix

**A)** `stream_generator()` now checks the device's cached now-playing state (via `DeviceStateManager`) before forwarding each chunk, and stops as soon as the device leaves `PLAY_STATE` or its station no longer matches this preset -- closing the upstream connection immediately instead of waiting for the device.

**B)** Both power-toggle call sites in `RadioPresets.tsx` now call `refresh()` from `useNowPlaying` right after the power API call resolves, so the UI updates immediately regardless of whether the SSE push arrives.

## Tests

- New unit test in `test_preset_stream_routes.py`: simulates the device reporting Stop mid-stream and asserts only the chunks sent before that point reach the client, and that the upstream connection is closed.
- New unit test in `RadioPresets.test.tsx`: clicking the power button triggers a `refresh()` call.
- Wired `app.state.device_state_manager` into the integration test app fixture (`tests/integration/conftest.py`), since the stream route now depends on it -- this was previously only needed by routes not covered by that fixture.
- Full backend suite (unit + integration) and full frontend suite pass with no regressions.

Closes #416.