### PR TITLE
feat(entrypoint): detect unsupported system page size at startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,85 @@ jobs:
 
       - name: Check for CP1252-as-UTF8 encoding corruption
         run: python scripts/check-mojibake.py .
+        
+  # ============================================================================
+  # PAGE SIZE REGRESSION TEST
+  # ============================================================================
 
+  test-page-size-detection:
+    name: Test page size detection
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Test page size compatibility handling
+        run: |
+          run_page_size_test() {
+            VALUE="$1"
+            EXPECT_REJECT="$2"
+            EXPECTED_TEXT="$3"
+            LABEL="$4"
+
+            mkdir -p /tmp/fakebin
+            mkdir -p /tmp/oct-data
+
+            cat > /tmp/fakebin/getconf <<EOF
+          #!/bin/sh
+          if [ "\$1" = "PAGE_SIZE" ]; then
+            printf '%s' "$VALUE"
+          else
+            /usr/bin/getconf "\$@"
+          fi
+          EOF
+
+            chmod +x /tmp/fakebin/getconf
+
+            set +e
+            OUTPUT=$(
+              PATH="/tmp/fakebin:$PATH" \
+              OCT_PORT=7777 \
+              OCT_LOG_LEVEL=INFO \
+              OCT_DB_PATH=/tmp/oct-data/oct.db \
+              OCT_HOST=0.0.0.0 \
+              OCT_DISCOVERY_ENABLED=false \
+              sh apps/backend/entrypoint.sh version 2>&1
+            )
+            STATUS=$?
+            set -e
+
+            echo "$OUTPUT"
+
+            if [ "$EXPECT_REJECT" = "true" ]; then
+              if [ "$STATUS" -ne 1 ]; then
+                echo "ERROR: Expected page size check to reject value '$VALUE'"
+                exit 1
+              fi
+            else
+              if echo "$OUTPUT" | grep -q "byte pages which is not supported"; then
+                echo "ERROR: Page size check unexpectedly rejected value '$VALUE'"
+                exit 1
+              fi
+            fi
+
+            if [ -n "$EXPECTED_TEXT" ] && ! echo "$OUTPUT" | grep -q "$EXPECTED_TEXT"; then
+              echo "ERROR: Expected output not found: $EXPECTED_TEXT"
+              exit 1
+            fi
+
+            echo "PASS: $LABEL"
+          }
+
+          run_page_size_test "4096" false "" "4KB page size accepted"
+          run_page_size_test "32768" true "32768-byte pages" "32KB page size rejected"
+          run_page_size_test "" false "Unable to determine system page size" "Empty page size handled with warning"
+          run_page_size_test "abc" false "Unable to determine system page size" "Non-numeric page size handled with warning"
+
+          echo "PASS: All page size compatibility tests passed."
+          
   # ============================================================================
   # COMMIT MESSAGE VALIDATION
   # ============================================================================
@@ -562,7 +640,7 @@ jobs:
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [mojibake-check, commit-lint, security, license-check, lint, backend-tests, frontend-tests, e2e-tests]
+    needs: [mojibake-check, test-page-size-detection, commit-lint, security, license-check, lint, backend-tests, frontend-tests, e2e-tests]
     if: always()
     permissions:
       pull-requests: write
@@ -589,6 +667,7 @@ jobs:
           echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-----|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Mojibake Check| ${{ needs.mojibake-check.result == 'success' && 'Passed' || 'Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Page Size Test| ${{ needs.test-page-size-detection.result == 'success' && 'Passed' || 'Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Commit Lint   | ${{ needs.commit-lint.result == 'success' && 'Passed' || needs.commit-lint.result == 'skipped' && 'Skipped' || 'Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Security Scan | ${{ needs.security.result == 'success' && 'Passed' || 'Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| License Check | ${{ needs.license-check.result == 'success' && 'Passed' || 'Failed' }} |" >> $GITHUB_STEP_SUMMARY
@@ -615,6 +694,7 @@ jobs:
         run: |
           if [[ "${{ needs.commit-lint.result }}" != "success" && "${{ needs.commit-lint.result }}" != "skipped" ]] || \
              [[ "${{ needs.mojibake-check.result }}" != "success" ]] || \
+             [[ "${{ needs.test-page-size-detection.result }}" != "success" ]] || \
              [[ "${{ needs.security.result }}" != "success" ]] || \
              [[ "${{ needs.license-check.result }}" != "success" ]] || \
              [[ "${{ needs.lint.result }}" != "success" ]] || \
@@ -631,6 +711,7 @@ jobs:
             const statusIcon = (result) => result === 'success' ? '✅' : result === 'skipped' ? '⏭️' : '❌';
             const jobs = [
               ['Mojibake Check', '${{ needs.mojibake-check.result }}'],
+              ['Page Size Test', '${{ needs.test-page-size-detection.result }}'],
               ['Commit Lint', '${{ needs.commit-lint.result }}'],
               ['Security Scan', '${{ needs.security.result }}'],
               ['License Check', '${{ needs.license-check.result }}'],

--- a/apps/backend/entrypoint.sh
+++ b/apps/backend/entrypoint.sh
@@ -22,6 +22,24 @@ log_error() {
     echo "${RED}[ERROR]${NC} $1"
 }
 
+# Check system page size compatibility
+check_page_size() {
+    PAGE_SIZE=$(getconf PAGE_SIZE 2>/dev/null || true)
+
+    if ! echo "$PAGE_SIZE" | grep -qE '^[0-9]+$'; then
+        log_warn "Unable to determine system page size; continuing without page-size compatibility check."
+        return 0
+    fi
+
+    if [ "$PAGE_SIZE" -gt 4096 ]; then
+        log_error "This platform uses ${PAGE_SIZE}-byte pages which is not supported by Python/Docker."
+        log_error "Supported platforms: Standard Linux (4KB pages), Raspberry Pi, x86/x64."
+        log_error "Unsupported: QNAP ARM NAS (32KB pages)."
+        log_error "See: https://www.qnap.com/en-uk/how-to/faq/article/why-do-the-installed-third-party-containers-not-run-successfully-on-specific-32-bit-arm-devices"
+        exit 1
+    fi
+}
+
 # Validate required environment variables
 validate_env() {
     log_info "Validating environment variables..."
@@ -113,6 +131,9 @@ fix_permissions() {
 
 # Main entrypoint logic
 main() {
+    # Check system page size compatibility
+    check_page_size
+    
     # Fix volume permissions before dropping privileges (runs as root)
     fix_permissions
 


### PR DESCRIPTION
Fixes #346
Related to #344

Implements the startup page-size detection proposed in #346.

The implementation intentionally stays close to the low-effort Option 1 described in the spec.

Changes:

* detect the system page size using `getconf PAGE_SIZE`
* abort startup when the page size is greater than 4096 bytes
* show a clear error message including the detected page size
* provide a link to the relevant QNAP documentation
* run the check before the normal OCT startup process

Testing:

* simulated a 32KB page size by temporarily overriding `getconf PAGE_SIZE` in a GitHub Actions workflow in my fork
* confirmed that 32768-byte pages are rejected with exit code 1
* confirmed that the expected error message and QNAP documentation link are shown
* simulated a standard 4KB page size in the same way
* confirmed that the page-size check does not reject 4096-byte pages and that the entrypoint continues through the normal validation path successfully to the `version` command with exit code 0

The temporary test workflow was used only in my fork for verification and was removed afterwards, so it is not part of this PR.

I did not use the regular OCT test-build workflow for this verification. I hope the isolated entrypoint test described above is sufficient for this change. If testing through the project's standard workflow is preferred, I am happy to adjust this.

I can also help with additional testing on a real Raspberry Pi using the standard 4096-byte page size if useful.
