### PR TITLE
feat(devices): add reboot device API endpoint and implement reboot functionality

### DIFF
--- a/apps/backend/openapi.yaml
+++ b/apps/backend/openapi.yaml
@@ -433,6 +433,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/devices/{device_id}/reboot:
+    get:
+      tags:
+      - Devices
+      summary: Reboot Device
+      description: Reboot a device.
+      operationId: reboot_device_api_devices__device_id__reboot_get
+      parameters:
+      - name: device_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Device Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/presets/set:
     post:
       tags:

--- a/apps/backend/openapi.yaml
+++ b/apps/backend/openapi.yaml
@@ -434,12 +434,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
   /api/devices/{device_id}/reboot:
-    get:
+    post:
       tags:
       - Devices
       summary: Reboot Device
       description: Reboot a device.
-      operationId: reboot_device_api_devices__device_id__reboot_get
+      operationId: reboot_device_api_devices__device_id__reboot_post
       parameters:
       - name: device_id
         in: path
@@ -452,7 +452,20 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  device_id:
+                    type: string
+                required:
+                - message
+                - device_id
+        '404':
+          description: Device not found
+        '503':
+          description: Device unreachable
         '422':
           description: Validation Error
           content:

--- a/apps/backend/src/opencloudtouch/devices/api/routes.py
+++ b/apps/backend/src/opencloudtouch/devices/api/routes.py
@@ -600,3 +600,19 @@ async def set_mute(
         device_service.set_mute(device_id, muted),
     )
     return {"actual": vol.actual, "target": vol.target, "muted": vol.muted}
+
+
+@router.get("/{device_id}/reboot")
+async def reboot_device(
+    device_id: str,
+    device_service: DeviceService = Depends(get_device_service),
+    state_manager: DeviceStateManager = Depends(get_device_state_manager),
+):
+    """Reboot a device."""
+    await _device_op(
+        device_id,
+        "reboot device",
+        device_service.reboot_device(device_id),
+        state_manager=state_manager,
+    )
+    return {"message": "Reboot command sent", "device_id": device_id}

--- a/apps/backend/src/opencloudtouch/devices/api/routes.py
+++ b/apps/backend/src/opencloudtouch/devices/api/routes.py
@@ -602,7 +602,7 @@ async def set_mute(
     return {"actual": vol.actual, "target": vol.target, "muted": vol.muted}
 
 
-@router.get("/{device_id}/reboot")
+@router.post("/{device_id}/reboot", responses={404: {"description": "Device not found"}, 503: {"description": "Device unreachable"}})
 async def reboot_device(
     device_id: str,
     device_service: DeviceService = Depends(get_device_service),

--- a/apps/backend/src/opencloudtouch/devices/client.py
+++ b/apps/backend/src/opencloudtouch/devices/client.py
@@ -183,3 +183,8 @@ class DeviceClient(ABC):
     async def remove_zone(self) -> None:
         """Dissolve entire zone (must be called on master)."""
         pass
+
+    @abstractmethod
+    async def reboot(self) -> None:
+        """Reboot the device via TCP telnet interface (port 17000)."""
+        pass

--- a/apps/backend/src/opencloudtouch/devices/client_adapter.py
+++ b/apps/backend/src/opencloudtouch/devices/client_adapter.py
@@ -563,7 +563,7 @@ class BoseDeviceClientAdapter(DeviceClient):
     async def reboot(self) -> None:
         """Reboot the device via TCP telnet interface (port 17000)."""
         try:
-            reader, writer = await asyncio.open_connection(self.ip, 17000)
+            reader, writer = await asyncio.wait_for(asyncio.open_connection(self.ip, 17000), timeout=5.0)
             try:
                 writer.write(b"sys reboot\n")
                 await writer.drain()

--- a/apps/backend/src/opencloudtouch/devices/client_adapter.py
+++ b/apps/backend/src/opencloudtouch/devices/client_adapter.py
@@ -559,3 +559,18 @@ class BoseDeviceClientAdapter(DeviceClient):
         except Exception as e:
             logger.exception("Failed to remove zone on %s", self.base_url)
             raise DeviceConnectionError(self.ip, str(e)) from e
+
+    async def reboot(self) -> None:
+        """Reboot the device via TCP telnet interface (port 17000)."""
+        try:
+            reader, writer = await asyncio.open_connection(self.ip, 17000)
+            try:
+                writer.write(b"sys reboot\n")
+                await writer.drain()
+            finally:
+                writer.close()
+                await writer.wait_closed()
+            logger.info("Reboot command sent to %s", self.ip)
+        except Exception as e:
+            logger.exception("Failed to reboot device at %s", self.ip)
+            raise DeviceConnectionError(self.ip, str(e)) from e

--- a/apps/backend/src/opencloudtouch/devices/mock_client.py
+++ b/apps/backend/src/opencloudtouch/devices/mock_client.py
@@ -285,3 +285,7 @@ class MockDeviceClient(DeviceClient):
         """Mock remove zone."""
         logger.info("[MOCK] remove_zone() for device %s", self.device_id)
         self._zone = None
+
+    async def reboot(self) -> None:
+        """Mock reboot (no-op)."""
+        logger.info("[MOCK] reboot() for device %s", self.device_id)

--- a/apps/backend/src/opencloudtouch/devices/service.py
+++ b/apps/backend/src/opencloudtouch/devices/service.py
@@ -410,3 +410,8 @@ class DeviceService:
         async with self._device_client(device_id) as client:
             await client.set_mute(muted)
             return await client.get_volume()
+
+    async def reboot_device(self, device_id: str) -> None:
+        """Send reboot command to device."""
+        async with self._device_client(device_id) as client:
+            await client.reboot()

--- a/apps/frontend/src/api/devices.ts
+++ b/apps/frontend/src/api/devices.ts
@@ -266,3 +266,10 @@ export async function prevTrack(deviceId: string): Promise<void> {
 export async function power(deviceId: string): Promise<void> {
   return sendKey(deviceId, "POWER");
 }
+
+export async function rebootDevice(deviceId: string): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/api/devices/${deviceId}/reboot`, {
+    method: "POST",
+  });
+  await throwIfNotOk(response, "Failed to reboot device");
+}

--- a/apps/frontend/src/components/wizard/DeviceInfoHeader.css
+++ b/apps/frontend/src/components/wizard/DeviceInfoHeader.css
@@ -53,3 +53,42 @@
   font-family: var(--font-mono, monospace);
   opacity: 0.8;
 }
+
+.device-reboot-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.device-reboot-btn:hover:not(:disabled) {
+  background: var(--color-bg-hover, rgba(255, 255, 255, 0.06));
+  color: var(--color-text-primary);
+  border-color: var(--color-text-secondary);
+}
+
+.device-reboot-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.device-reboot-btn--sent {
+  border-color: var(--color-success, #4caf50);
+  color: var(--color-success, #4caf50);
+  cursor: default;
+}
+
+.device-reboot-btn--error {
+  border-color: var(--color-error, #ef4444);
+  color: var(--color-error, #ef4444);
+}

--- a/apps/frontend/src/components/wizard/DeviceInfoHeader.tsx
+++ b/apps/frontend/src/components/wizard/DeviceInfoHeader.tsx
@@ -2,7 +2,9 @@
  * Device Info Header for Setup Wizard
  * Shows device name, model, and IP at top of wizard
  */
-import { Device } from "../../api/devices";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Device, rebootDevice } from "../../api/devices";
 import "./DeviceInfoHeader.css";
 
 interface DeviceInfoHeaderProps {
@@ -10,6 +12,21 @@ interface DeviceInfoHeaderProps {
 }
 
 export default function DeviceInfoHeader({ device }: DeviceInfoHeaderProps) {
+  const { t } = useTranslation();
+  const [rebootState, setRebootState] = useState<"idle" | "sent" | "error">("idle");
+
+  const handleReboot = async () => {
+    if (rebootState === "sent") return;
+    try {
+      await rebootDevice(device.device_id);
+      setRebootState("sent");
+      setTimeout(() => setRebootState("idle"), 5000);
+    } catch {
+      setRebootState("error");
+      setTimeout(() => setRebootState("idle"), 5000);
+    }
+  };
+
   return (
     <div className="device-info-header">
       <div className="device-icon">🔊</div>
@@ -21,6 +38,16 @@ export default function DeviceInfoHeader({ device }: DeviceInfoHeaderProps) {
           <span className="device-ip">{device.ip}</span>
         </div>
       </div>
+      <button
+        className={`device-reboot-btn device-reboot-btn--${rebootState}`}
+        onClick={handleReboot}
+        disabled={rebootState === "sent"}
+        title={t("deviceHeader.reboot")}
+      >
+        {rebootState === "idle" && <>↺ {t("deviceHeader.reboot")}</>}
+        {rebootState === "sent" && t("deviceHeader.sent")}
+        {rebootState === "error" && "✕"}
+      </button>
     </div>
   );
 }

--- a/apps/frontend/src/components/wizard/DeviceInfoHeader.tsx
+++ b/apps/frontend/src/components/wizard/DeviceInfoHeader.tsx
@@ -5,6 +5,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Device, rebootDevice } from "../../api/devices";
+import ConfirmDialog from "../ConfirmDialog";
 import "./DeviceInfoHeader.css";
 
 interface DeviceInfoHeaderProps {
@@ -14,9 +15,10 @@ interface DeviceInfoHeaderProps {
 export default function DeviceInfoHeader({ device }: DeviceInfoHeaderProps) {
   const { t } = useTranslation();
   const [rebootState, setRebootState] = useState<"idle" | "sent" | "error">("idle");
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const handleReboot = async () => {
-    if (rebootState === "sent") return;
+    setConfirmOpen(false);
     try {
       await rebootDevice(device.device_id);
       setRebootState("sent");
@@ -40,7 +42,7 @@ export default function DeviceInfoHeader({ device }: DeviceInfoHeaderProps) {
       </div>
       <button
         className={`device-reboot-btn device-reboot-btn--${rebootState}`}
-        onClick={handleReboot}
+        onClick={() => setConfirmOpen(true)}
         disabled={rebootState === "sent"}
         title={t("deviceHeader.reboot")}
       >
@@ -48,6 +50,14 @@ export default function DeviceInfoHeader({ device }: DeviceInfoHeaderProps) {
         {rebootState === "sent" && t("deviceHeader.sent")}
         {rebootState === "error" && "✕"}
       </button>
+      <ConfirmDialog
+        open={confirmOpen}
+        title={t("deviceHeader.reboot")}
+        message={t("deviceHeader.confirmMessage", { name: device.name || device.device_id })}
+        confirmLabel={t("deviceHeader.reboot")}
+        onConfirm={handleReboot}
+        onCancel={() => setConfirmOpen(false)}
+      />
     </div>
   );
 }

--- a/apps/frontend/src/i18n/locales/de.json
+++ b/apps/frontend/src/i18n/locales/de.json
@@ -763,6 +763,7 @@
   },
   "deviceHeader": {
     "reboot": "Reboot device",
-    "sent": "Reboot command sent"
+    "sent": "Reboot command sent",
+    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
   }
 }

--- a/apps/frontend/src/i18n/locales/de.json
+++ b/apps/frontend/src/i18n/locales/de.json
@@ -762,8 +762,8 @@
     "failed": "Umbenennung fehlgeschlagen"
   },
   "deviceHeader": {
-    "reboot": "Reboot device",
-    "sent": "Reboot command sent",
-    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
+    "reboot": "Gerät neu starten",
+    "sent": "Neustart-Befehl gesendet",
+    "confirmMessage": "{{name}} neu starten? Das Gerät ist für ca. 60 Sekunden nicht erreichbar."
   }
 }

--- a/apps/frontend/src/i18n/locales/de.json
+++ b/apps/frontend/src/i18n/locales/de.json
@@ -760,5 +760,9 @@
     "inputLabel": "Gerätename",
     "tooLong": "Name darf maximal 30 Zeichen lang sein",
     "failed": "Umbenennung fehlgeschlagen"
+  },
+  "deviceHeader": {
+    "reboot": "Reboot device",
+    "sent": "Reboot command sent"
   }
 }

--- a/apps/frontend/src/i18n/locales/en.json
+++ b/apps/frontend/src/i18n/locales/en.json
@@ -763,6 +763,7 @@
   },
   "deviceHeader": {
     "reboot": "Reboot device",
-    "sent": "Reboot command sent"
+    "sent": "Reboot command sent",
+    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
   }
 }

--- a/apps/frontend/src/i18n/locales/en.json
+++ b/apps/frontend/src/i18n/locales/en.json
@@ -760,5 +760,9 @@
     "inputLabel": "Device name",
     "tooLong": "Name must be 30 characters or fewer",
     "failed": "Failed to rename device"
+  },
+  "deviceHeader": {
+    "reboot": "Reboot device",
+    "sent": "Reboot command sent"
   }
 }

--- a/apps/frontend/src/i18n/locales/es.json
+++ b/apps/frontend/src/i18n/locales/es.json
@@ -657,7 +657,7 @@
     "hallOfFameDescription": "Los 3 mejores colaboradores de todos los tiempos — reconocidos por su impacto técnico excepcional.",
     "supportersTitle": "Patrocinadores",
     "reportBug": "Reportar error",
-    "diagnostics": "Diagn\u00f3sticos",
+    "diagnostics": "Diagnósticos",
     "supportersDescription": "Gracias a todos los que apoyan OpenCloudTouch financieramente. ¡Sus contribuciones ayudan a mantener el proyecto vivo!",
     "supportersMonthly": "Patrocinadores Mensuales",
     "supportersOneTime": "Patrocinadores Únicos",
@@ -760,5 +760,9 @@
     "inputLabel": "Nombre del dispositivo",
     "tooLong": "El nombre debe tener 30 caracteres o menos",
     "failed": "Error al renombrar el dispositivo"
+  },
+  "deviceHeader": {
+    "reboot": "Reboot device",
+    "sent": "Reboot command sent"
   }
 }

--- a/apps/frontend/src/i18n/locales/es.json
+++ b/apps/frontend/src/i18n/locales/es.json
@@ -763,6 +763,7 @@
   },
   "deviceHeader": {
     "reboot": "Reboot device",
-    "sent": "Reboot command sent"
+    "sent": "Reboot command sent",
+    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
   }
 }

--- a/apps/frontend/src/i18n/locales/es.json
+++ b/apps/frontend/src/i18n/locales/es.json
@@ -657,7 +657,7 @@
     "hallOfFameDescription": "Los 3 mejores colaboradores de todos los tiempos — reconocidos por su impacto técnico excepcional.",
     "supportersTitle": "Patrocinadores",
     "reportBug": "Reportar error",
-    "diagnostics": "Diagnósticos",
+    "diagnostics": "Diagn\u00f3sticos",
     "supportersDescription": "Gracias a todos los que apoyan OpenCloudTouch financieramente. ¡Sus contribuciones ayudan a mantener el proyecto vivo!",
     "supportersMonthly": "Patrocinadores Mensuales",
     "supportersOneTime": "Patrocinadores Únicos",
@@ -762,8 +762,8 @@
     "failed": "Error al renombrar el dispositivo"
   },
   "deviceHeader": {
-    "reboot": "Reboot device",
-    "sent": "Reboot command sent",
-    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
+    "reboot": "Reiniciar dispositivo",
+    "sent": "Comando de reinicio enviado",
+    "confirmMessage": "¿Reiniciar {{name}}? El dispositivo no estará disponible durante unos 60 segundos."
   }
 }

--- a/apps/frontend/src/i18n/locales/fr.json
+++ b/apps/frontend/src/i18n/locales/fr.json
@@ -760,5 +760,9 @@
     "inputLabel": "Nom de l'appareil",
     "tooLong": "Le nom doit comporter 30 caractères maximum",
     "failed": "Échec du renommage"
+  },
+  "deviceHeader": {
+    "reboot": "Reboot device",
+    "sent": "Reboot command sent"
   }
 }

--- a/apps/frontend/src/i18n/locales/fr.json
+++ b/apps/frontend/src/i18n/locales/fr.json
@@ -762,8 +762,8 @@
     "failed": "Échec du renommage"
   },
   "deviceHeader": {
-    "reboot": "Reboot device",
-    "sent": "Reboot command sent",
-    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
+    "reboot": "Redémarrer l'appareil",
+    "sent": "Commande de redémarrage envoyée",
+    "confirmMessage": "Redémarrer {{name}} ? L'appareil sera indisponible pendant environ 60 secondes."
   }
 }

--- a/apps/frontend/src/i18n/locales/fr.json
+++ b/apps/frontend/src/i18n/locales/fr.json
@@ -763,6 +763,7 @@
   },
   "deviceHeader": {
     "reboot": "Reboot device",
-    "sent": "Reboot command sent"
+    "sent": "Reboot command sent",
+    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
   }
 }

--- a/apps/frontend/src/i18n/locales/it.json
+++ b/apps/frontend/src/i18n/locales/it.json
@@ -760,5 +760,9 @@
     "inputLabel": "Nome dispositivo",
     "tooLong": "Il nome deve avere al massimo 30 caratteri",
     "failed": "Rinominazione non riuscita"
+  },
+  "deviceHeader": {
+    "reboot": "Reboot device",
+    "sent": "Reboot command sent"
   }
 }

--- a/apps/frontend/src/i18n/locales/it.json
+++ b/apps/frontend/src/i18n/locales/it.json
@@ -763,6 +763,7 @@
   },
   "deviceHeader": {
     "reboot": "Reboot device",
-    "sent": "Reboot command sent"
+    "sent": "Reboot command sent",
+    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
   }
 }

--- a/apps/frontend/src/i18n/locales/it.json
+++ b/apps/frontend/src/i18n/locales/it.json
@@ -762,8 +762,8 @@
     "failed": "Rinominazione non riuscita"
   },
   "deviceHeader": {
-    "reboot": "Reboot device",
-    "sent": "Reboot command sent",
-    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
+    "reboot": "Riavvia il dispositivo",
+    "sent": "Comando di riavvio inviato",
+    "confirmMessage": "Riavviare {{name}}? Il dispositivo non sarà disponibile per circa 60 secondi."
   }
 }

--- a/apps/frontend/src/i18n/locales/ja.json
+++ b/apps/frontend/src/i18n/locales/ja.json
@@ -763,6 +763,7 @@
   },
   "deviceHeader": {
     "reboot": "Reboot device",
-    "sent": "Reboot command sent"
+    "sent": "Reboot command sent",
+    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
   }
 }

--- a/apps/frontend/src/i18n/locales/ja.json
+++ b/apps/frontend/src/i18n/locales/ja.json
@@ -760,5 +760,9 @@
     "inputLabel": "デバイス名",
     "tooLong": "名前は30文字以内にする必要があります",
     "failed": "名前の変更に失敗しました"
+  },
+  "deviceHeader": {
+    "reboot": "Reboot device",
+    "sent": "Reboot command sent"
   }
 }

--- a/apps/frontend/src/i18n/locales/ja.json
+++ b/apps/frontend/src/i18n/locales/ja.json
@@ -762,8 +762,8 @@
     "failed": "名前の変更に失敗しました"
   },
   "deviceHeader": {
-    "reboot": "Reboot device",
-    "sent": "Reboot command sent",
-    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
+    "reboot": "デバイスを再起動",
+    "sent": "再起動コマンドを送信しました",
+    "confirmMessage": "{{name}}を再起動しますか？デバイスは約60秒間使用できなくなります。"
   }
 }

--- a/apps/frontend/src/i18n/locales/nl.json
+++ b/apps/frontend/src/i18n/locales/nl.json
@@ -763,6 +763,7 @@
   },
   "deviceHeader": {
     "reboot": "Reboot device",
-    "sent": "Reboot command sent"
+    "sent": "Reboot command sent",
+    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
   }
 }

--- a/apps/frontend/src/i18n/locales/nl.json
+++ b/apps/frontend/src/i18n/locales/nl.json
@@ -762,8 +762,8 @@
     "failed": "Hernoemen mislukt"
   },
   "deviceHeader": {
-    "reboot": "Reboot device",
-    "sent": "Reboot command sent",
-    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
+    "reboot": "Apparaat herstarten",
+    "sent": "Herstartopdracht verzonden",
+    "confirmMessage": "{{name}} herstarten? Het apparaat is ongeveer 60 seconden niet beschikbaar."
   }
 }

--- a/apps/frontend/src/i18n/locales/nl.json
+++ b/apps/frontend/src/i18n/locales/nl.json
@@ -760,5 +760,9 @@
     "inputLabel": "Apparaatnaam",
     "tooLong": "Naam mag maximaal 30 tekens bevatten",
     "failed": "Hernoemen mislukt"
+  },
+  "deviceHeader": {
+    "reboot": "Reboot device",
+    "sent": "Reboot command sent"
   }
 }

--- a/apps/frontend/src/i18n/locales/pl.json
+++ b/apps/frontend/src/i18n/locales/pl.json
@@ -760,5 +760,9 @@
     "inputLabel": "Nazwa urządzenia",
     "tooLong": "Nazwa musi mieć maksymalnie 30 znaków",
     "failed": "Nie udało się zmienić nazwy"
+  },
+  "deviceHeader": {
+    "reboot": "Reboot device",
+    "sent": "Reboot command sent"
   }
 }

--- a/apps/frontend/src/i18n/locales/pl.json
+++ b/apps/frontend/src/i18n/locales/pl.json
@@ -762,8 +762,8 @@
     "failed": "Nie udało się zmienić nazwy"
   },
   "deviceHeader": {
-    "reboot": "Reboot device",
-    "sent": "Reboot command sent",
-    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
+    "reboot": "Uruchom ponownie urządzenie",
+    "sent": "Polecenie restartu wysłane",
+    "confirmMessage": "Uruchomić ponownie {{name}}? Urządzenie będzie niedostępne przez około 60 sekund."
   }
 }

--- a/apps/frontend/src/i18n/locales/pl.json
+++ b/apps/frontend/src/i18n/locales/pl.json
@@ -763,6 +763,7 @@
   },
   "deviceHeader": {
     "reboot": "Reboot device",
-    "sent": "Reboot command sent"
+    "sent": "Reboot command sent",
+    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
   }
 }

--- a/apps/frontend/src/i18n/locales/pt-BR.json
+++ b/apps/frontend/src/i18n/locales/pt-BR.json
@@ -763,6 +763,7 @@
   },
   "deviceHeader": {
     "reboot": "Reboot device",
-    "sent": "Reboot command sent"
+    "sent": "Reboot command sent",
+    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
   }
 }

--- a/apps/frontend/src/i18n/locales/pt-BR.json
+++ b/apps/frontend/src/i18n/locales/pt-BR.json
@@ -657,7 +657,7 @@
     "hallOfFameDescription": "Top 3 colaboradores de todos os tempos — reconhecidos pelo impacto técnico excepcional.",
     "supportersTitle": "Apoiadores",
     "reportBug": "Relatar bug",
-    "diagnostics": "Diagn\u00f3sticos",
+    "diagnostics": "Diagnósticos",
     "supportersDescription": "Obrigado a todos que apoiam o OpenCloudTouch financeiramente. Suas contribuições ajudam a manter o projeto vivo!",
     "supportersMonthly": "Apoiadores Mensais",
     "supportersOneTime": "Apoiadores únicos",
@@ -760,5 +760,9 @@
     "inputLabel": "Nome do dispositivo",
     "tooLong": "O nome deve ter no máximo 30 caracteres",
     "failed": "Falha ao renomear o dispositivo"
+  },
+  "deviceHeader": {
+    "reboot": "Reboot device",
+    "sent": "Reboot command sent"
   }
 }

--- a/apps/frontend/src/i18n/locales/pt-BR.json
+++ b/apps/frontend/src/i18n/locales/pt-BR.json
@@ -657,7 +657,7 @@
     "hallOfFameDescription": "Top 3 colaboradores de todos os tempos — reconhecidos pelo impacto técnico excepcional.",
     "supportersTitle": "Apoiadores",
     "reportBug": "Relatar bug",
-    "diagnostics": "Diagnósticos",
+    "diagnostics": "Diagn\u00f3sticos",
     "supportersDescription": "Obrigado a todos que apoiam o OpenCloudTouch financeiramente. Suas contribuições ajudam a manter o projeto vivo!",
     "supportersMonthly": "Apoiadores Mensais",
     "supportersOneTime": "Apoiadores únicos",
@@ -762,8 +762,8 @@
     "failed": "Falha ao renomear o dispositivo"
   },
   "deviceHeader": {
-    "reboot": "Reboot device",
-    "sent": "Reboot command sent",
-    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
+    "reboot": "Reiniciar dispositivo",
+    "sent": "Comando de reinicialização enviado",
+    "confirmMessage": "Reiniciar {{name}}? O dispositivo ficará indisponível por cerca de 60 segundos."
   }
 }

--- a/apps/frontend/src/i18n/locales/sv.json
+++ b/apps/frontend/src/i18n/locales/sv.json
@@ -762,8 +762,8 @@
     "failed": "Det gick inte att byta namn"
   },
   "deviceHeader": {
-    "reboot": "Reboot device",
-    "sent": "Reboot command sent",
-    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
+    "reboot": "Starta om enheten",
+    "sent": "Omstartskommando skickat",
+    "confirmMessage": "Starta om {{name}}? Enheten kommer att vara otillgänglig i ungefär 60 sekunder."
   }
 }

--- a/apps/frontend/src/i18n/locales/sv.json
+++ b/apps/frontend/src/i18n/locales/sv.json
@@ -763,6 +763,7 @@
   },
   "deviceHeader": {
     "reboot": "Reboot device",
-    "sent": "Reboot command sent"
+    "sent": "Reboot command sent",
+    "confirmMessage": "Reboot {{name}}? The device will be unavailable for about 60 seconds."
   }
 }

--- a/apps/frontend/src/i18n/locales/sv.json
+++ b/apps/frontend/src/i18n/locales/sv.json
@@ -760,5 +760,9 @@
     "inputLabel": "Enhetsnamn",
     "tooLong": "Namnet får ha max 30 tecken",
     "failed": "Det gick inte att byta namn"
+  },
+  "deviceHeader": {
+    "reboot": "Reboot device",
+    "sent": "Reboot command sent"
   }
 }


### PR DESCRIPTION
## Add Reboot Speaker Endpoint

### What
Adds `GET /api/devices/{device_id}/reboot` to trigger a device reboot via the TCP telnet interface (port 17000, `sys reboot` command).

### Changes
- **`devices/client.py`** — added abstract `reboot()` method to `DeviceClient`
- **`devices/client_adapter.py`** — implemented `reboot()` using `asyncio.open_connection` on port 17000
- **`devices/mock_client.py`** — added no-op mock implementation
- **`devices/service.py`** — added `reboot_device(device_id)` service method
- **`devices/api/routes.py`** — added `GET /{device_id}/reboot` endpoint
- **`openapi.yaml`** — added path entry for the new endpoint

### How it works
Opens a raw TCP connection to the device on port 17000, sends `sys reboot\n`, then closes the connection. The device drops the connection immediately on reboot, so no response is expected.

### Testing
Call `GET /api/devices/{device_id}/reboot` and expect `200 {"message": "Reboot command sent", "device_id": "..."}`.
