### PR TITLE
feat(devices): sort devices alphabetically by name

### DIFF
--- a/apps/backend/openapi.yaml
+++ b/apps/backend/openapi.yaml
@@ -116,8 +116,8 @@ paths:
       tags:
       - Devices
       summary: Get Devices
-      description: "Get all devices from database.\n\nReturns:\n    List of devices\
-        \ with details"
+      description: "Get all devices from database, sorted alphabetically by name (case-insensitive).\n\nReturns:\n    List of devices\
+          \ with details"
       operationId: get_devices_api_devices_get
       responses:
         '200':

--- a/apps/backend/src/opencloudtouch/devices/repository.py
+++ b/apps/backend/src/opencloudtouch/devices/repository.py
@@ -4,6 +4,7 @@ Uses aiosqlite for async SQLite operations
 """
 
 import logging
+import unicodedata
 from datetime import UTC, datetime
 from typing import Any, List, Optional
 
@@ -207,11 +208,14 @@ class DeviceRepository(BaseRepository):
                    schema_version, last_seen, setup_status, ssh_permanent,
                    setup_completed_at, marge_account_uuid
             FROM devices
-            ORDER BY last_seen DESC
         """)
 
         rows = await cursor.fetchall()
-        return [self._row_to_device(row) for row in rows]
+        devices = [self._row_to_device(row) for row in rows]
+        return sorted(
+            devices,
+            key=lambda d: unicodedata.normalize("NFKD", d.name).casefold(),
+        )
 
     async def get_by_device_id(self, device_id: str) -> Optional[Device]:
         """Get device by device_id."""

--- a/apps/backend/tests/unit/devices/test_repository.py
+++ b/apps/backend/tests/unit/devices/test_repository.py
@@ -165,6 +165,55 @@ async def test_device_get_all(repo):
     assert len(devices) == 2
     assert all(isinstance(d, Device) for d in devices)
 
+@pytest.mark.asyncio
+async def test_device_get_all_sorted_by_name_case_insensitive(repo):
+    """Test case-insensitive Unicode sorting by device name."""
+    devices = [
+        Device(
+            device_id="DEV_A",
+            ip="192.168.1.100",
+            name="Zulu",
+            model="SoundTouch 10",
+            mac_address="AA:BB:CC:DD:EE:01",
+            firmware_version="1.0.0",
+        ),
+        Device(
+            device_id="DEV_Z",
+            ip="192.168.1.101",
+            name="alpha",
+            model="SoundTouch 10",
+            mac_address="AA:BB:CC:DD:EE:02",
+            firmware_version="1.0.0",
+        ),
+        Device(
+            device_id="DEV_B",
+            ip="192.168.1.102",
+            name="Bravo",
+            model="SoundTouch 10",
+            mac_address="AA:BB:CC:DD:EE:03",
+            firmware_version="1.0.0",
+        ),
+        Device(
+            device_id="DEV_M",
+            ip="192.168.1.103",
+            name="Ärger",
+            model="SoundTouch 10",
+            mac_address="AA:BB:CC:DD:EE:04",
+            firmware_version="1.0.0",
+        ),
+    ]
+
+    for device in devices:
+        await repo.upsert(device)
+
+    result = await repo.get_all()
+
+    assert [device.name for device in result] == [
+        "alpha",
+        "Ärger",
+        "Bravo",
+        "Zulu",
+    ]
 
 @pytest.mark.asyncio
 async def test_device_get_by_device_id(repo):


### PR DESCRIPTION
## Summary

Implements #324 by sorting devices alphabetically by name in the backend API using Unicode-aware, case-insensitive sorting.

## Changes

* Replaced `last_seen DESC` ordering with Python-based alphabetical sorting by device name
* Added Unicode normalization and case folding for names with umlauts
* Added a regression test covering case-insensitive sorting and umlauts
* Documented the alphabetical sort order in `openapi.yaml`

## Behavior Changes

Device ordering changes from `last_seen DESC` to alphabetical sorting by name.

Newly discovered devices will no longer automatically appear at the top of the list. Instead, they will appear at their alphabetical position, providing a stable and predictable device order.

Sorting is case-insensitive and handles umlauts consistently, e.g. `alpha`, `Ärger`, `Bravo`, `Zulu`.

## Testing

* `tests/unit/devices/test_repository.py`
* 27/27 tests passed

Closes #324