### PR TITLE
feat(devices): add backend bass control and persist device capabilities

### DIFF
--- a/apps/backend/openapi.yaml
+++ b/apps/backend/openapi.yaml
@@ -3322,6 +3322,51 @@ paths:
           content:
             application/json:
               schema: {}
+  /api/devices/{device_id}/settings/bass:
+    get:
+      tags:
+        - Devices
+      summary: Get Device Bass
+      description: Get the current bass state reported by the selected SoundTouch device.
+      operationId: get_device_bass_api_devices__device_id__settings_bass_get
+      parameters:
+        - name: device_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Device Id
+      responses:
+        "200":
+          description: Successful Response
+        "422":
+          description: Validation Error
+    put:
+      tags:
+        - Devices
+      summary: Set Device Bass
+      description: Set the bass level supported by the selected SoundTouch device.
+      operationId: set_device_bass_api_devices__device_id__settings_bass_put
+      parameters:
+        - name: device_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Device Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              title: Body
+      responses:
+        "200":
+          description: Successful Response
+        "422":
+          description: Invalid bass level
+
 components:
   schemas:
     AccountPairingRequest:

--- a/apps/backend/src/opencloudtouch/devices/api/routes.py
+++ b/apps/backend/src/opencloudtouch/devices/api/routes.py
@@ -199,6 +199,47 @@ async def get_device_capabilities_endpoint(
     )
 
 
+@router.get("/{device_id}/settings/bass")
+async def get_device_bass(
+    device_id: str,
+    device_service: DeviceService = Depends(get_device_service),
+):
+    """Get the current bass state reported by a SoundTouch device."""
+    bass = await _device_op(
+        device_id,
+        "get bass",
+        device_service.get_device_bass(device_id),
+    )
+    return {"actual": bass.actual, "target": bass.target}
+
+
+@router.put(
+    "/{device_id}/settings/bass",
+    responses={422: {"description": "Invalid bass level"}},
+)
+async def set_device_bass(
+    device_id: str,
+    body: Annotated[dict, Body()],
+    device_service: Annotated[DeviceService, Depends(get_device_service)],
+):
+    """Set the bass level supported by the selected SoundTouch device."""
+    level = body.get("level")
+
+    if isinstance(level, bool) or not isinstance(level, int):
+        raise HTTPException(status_code=422, detail="Bass level must be an integer")
+
+    try:
+        await device_service.set_device_bass(device_id, level)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    return {
+        "message": "Bass level updated successfully",
+        "device_id": device_id,
+        "level": level,
+    }
+
+
 @router.post("/{device_id}/key")
 async def press_key(
     device_id: str,

--- a/apps/backend/src/opencloudtouch/devices/capabilities.py
+++ b/apps/backend/src/opencloudtouch/devices/capabilities.py
@@ -96,16 +96,32 @@ async def get_device_capabilities(client: SoundTouchClient) -> DeviceCapabilitie
         asyncio.to_thread(client.GetSourceList),
     )
 
-    # Parse supported endpoints from supportedURLs
+    # Parse supported endpoints. bosesoundtouchapi versions expose these
+    # either as SupportedUrls objects or as an internal _Capabilities mapping.
     supported_endpoints = set()
-    for url_obj in caps.SupportedUrls:
-        # url_obj is SupportedUrl with Url property
-        endpoint = url_obj.Url.lstrip("/")
-        supported_endpoints.add(endpoint)
+    supported_urls = getattr(caps, "SupportedUrls", None)
+    if supported_urls is not None:
+        for url_obj in supported_urls:
+            endpoint = url_obj.Url.lstrip("/")
+            supported_endpoints.add(endpoint)
+    else:
+        capability_map = getattr(caps, "_Capabilities", {}) or {}
+        if isinstance(capability_map, dict):
+            for endpoint_path in capability_map.values():
+                supported_endpoints.add(str(endpoint_path).lstrip("/"))
 
-    # Parse available sources
+    # Parse available sources. bosesoundtouchapi versions expose these
+    # either as Sources or as SourceItems/_SourceItems.
+    source_items = getattr(sources_response, "Sources", None)
+    if source_items is None:
+        source_items = getattr(sources_response, "SourceItems", None)
+    if source_items is None:
+        source_items = getattr(sources_response, "_SourceItems", [])
+
     supported_sources = [
-        source.Source for source in sources_response.Sources if source.Status == "READY"
+        source.Source
+        for source in source_items
+        if getattr(source, "Status", None) == "READY"
     ]
 
     # Build capabilities object
@@ -113,9 +129,19 @@ async def get_device_capabilities(client: SoundTouchClient) -> DeviceCapabilitie
         device_id=info.DeviceId,
         device_type=info.DeviceType,
         # Hardware capabilities from /capabilities
-        has_hdmi_control=caps.IsProductCECHDMIControlCapable,
-        has_bass_control=caps.IsBassCapable,
-        has_audio_product_level_control=caps.IsAudioProductLevelControlCapable,
+        has_hdmi_control=getattr(
+            caps,
+            "IsProductCECHDMIControlCapable",
+            getattr(caps, "IsProductCecHdmiControlCapable", False),
+        ),
+        # Not all bosesoundtouchapi versions expose IsBassCapable.
+        # Bass support is verified separately via /bassCapabilities.
+        has_bass_control=getattr(caps, "IsBassCapable", False),
+        has_audio_product_level_control=getattr(
+            caps,
+            "IsAudioProductLevelControlCapable",
+            getattr(caps, "IsAudioProductLevelControlsCapable", False),
+        ),
         has_audio_product_tone_control=(
             caps.IsAudioProductToneControlsCapable
             if hasattr(caps, "IsAudioProductToneControlsCapable")

--- a/apps/backend/src/opencloudtouch/devices/client.py
+++ b/apps/backend/src/opencloudtouch/devices/client.py
@@ -50,6 +50,24 @@ class VolumeInfo:
     muted: bool  # Whether device is muted
 
 
+@dataclass
+class BassInfo:
+    """Device bass state."""
+
+    actual: int
+    target: int
+
+
+@dataclass
+class BassCapabilities:
+    """Device bass capabilities."""
+
+    available: bool
+    minimum: int
+    maximum: int
+    default: int
+
+
 class DeviceClient(ABC):
     """Abstract client for device HTTP API."""
 
@@ -109,6 +127,21 @@ class DeviceClient(ABC):
     @abstractmethod
     async def set_mute(self, muted: bool) -> None:
         """Set mute state."""
+        pass
+
+    @abstractmethod
+    async def get_bass(self) -> BassInfo:
+        """Get current bass state."""
+        pass
+
+    @abstractmethod
+    async def get_bass_capabilities(self) -> BassCapabilities:
+        """Get supported bass capabilities."""
+        pass
+
+    @abstractmethod
+    async def set_bass(self, level: int) -> None:
+        """Set bass level."""
         pass
 
     @abstractmethod

--- a/apps/backend/src/opencloudtouch/devices/client_adapter.py
+++ b/apps/backend/src/opencloudtouch/devices/client_adapter.py
@@ -10,6 +10,7 @@ import base64
 import json
 import logging
 from urllib.parse import urlparse
+from defusedxml import ElementTree
 from xml.sax.saxutils import escape as xml_escape
 
 import httpx
@@ -18,6 +19,8 @@ from bosesoundtouchapi import SoundTouchDevice
 
 from opencloudtouch.core.exceptions import DeviceConnectionError
 from opencloudtouch.devices.client import (
+    BassCapabilities,
+    BassInfo,
     DeviceClient,
     DeviceInfo,
     NowPlayingInfo,
@@ -371,6 +374,86 @@ class BoseDeviceClientAdapter(DeviceClient):
                 await asyncio.to_thread(self._client.MuteOff, refresh=False)
         except Exception as e:
             logger.exception("Failed to set mute on %s", self.base_url)
+            raise DeviceConnectionError(self.ip, str(e)) from e
+
+    async def get_bass(self) -> BassInfo:
+        """Get current bass state from the device."""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(f"{self.base_url}/bass")
+                response.raise_for_status()
+
+            root = ElementTree.fromstring(response.text)
+            target_text = root.findtext("targetbass")
+            actual_text = root.findtext("actualbass")
+            if target_text is None or actual_text is None:
+                raise ValueError("Invalid /bass response")
+
+            return BassInfo(
+                target=int(target_text),
+                actual=int(actual_text),
+            )
+
+        except httpx.HTTPStatusError as e:
+            raise DeviceConnectionError(
+                self.ip, f"HTTP {e.response.status_code}"
+            ) from e
+        except Exception as e:
+            logger.exception("Failed to get bass from %s", self.base_url)
+            raise DeviceConnectionError(self.ip, str(e)) from e
+
+    async def get_bass_capabilities(self) -> BassCapabilities:
+        """Get supported bass range from the device."""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(f"{self.base_url}/bassCapabilities")
+                response.raise_for_status()
+
+            root = ElementTree.fromstring(response.text)
+            available_text = root.findtext("bassAvailable")
+            minimum_text = root.findtext("bassMin")
+            maximum_text = root.findtext("bassMax")
+            default_text = root.findtext("bassDefault")
+
+            if None in (
+                available_text,
+                minimum_text,
+                maximum_text,
+                default_text,
+            ):
+                raise ValueError("Invalid /bassCapabilities response")
+
+            return BassCapabilities(
+                available=available_text.strip().lower() == "true",
+                minimum=int(minimum_text),
+                maximum=int(maximum_text),
+                default=int(default_text),
+            )
+
+        except httpx.HTTPStatusError as e:
+            raise DeviceConnectionError(
+                self.ip, f"HTTP {e.response.status_code}"
+            ) from e
+        except Exception as e:
+            logger.exception("Failed to get bass capabilities from %s", self.base_url)
+            raise DeviceConnectionError(self.ip, str(e)) from e
+
+    async def set_bass(self, level: int) -> None:
+        """Set bass level on the device."""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.post(
+                    f"{self.base_url}/bass",
+                    content=f"<bass>{level}</bass>",
+                    headers={"Content-Type": "application/xml"},
+                )
+                response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise DeviceConnectionError(
+                self.ip, f"HTTP {e.response.status_code}"
+            ) from e
+        except Exception as e:
+            logger.exception("Failed to set bass on %s", self.base_url)
             raise DeviceConnectionError(self.ip, str(e)) from e
 
     async def set_name(self, name: str) -> None:

--- a/apps/backend/src/opencloudtouch/devices/mock_client.py
+++ b/apps/backend/src/opencloudtouch/devices/mock_client.py
@@ -8,6 +8,8 @@ import logging
 from typing import Optional
 
 from opencloudtouch.devices.client import (
+    BassCapabilities,
+    BassInfo,
     DeviceClient,
     DeviceInfo,
     NowPlayingInfo,
@@ -112,6 +114,7 @@ class MockDeviceClient(DeviceClient):
         self.device_id = device_id
         self.ip_address = ip_address
         self._volume = 45
+        self._bass = 0
         self._muted = False
         self._zone: ZoneStatus | None = None
 
@@ -198,6 +201,29 @@ class MockDeviceClient(DeviceClient):
         """Mock set mute."""
         logger.info("[MOCK] set_mute(%s) for device %s", muted, self.device_id)
         self._muted = muted
+
+    async def get_bass(self) -> BassInfo:
+        """Get mock bass state."""
+        return BassInfo(actual=self._bass, target=self._bass)
+
+    async def get_bass_capabilities(self) -> BassCapabilities:
+        """Get mock bass capabilities."""
+        return BassCapabilities(
+            available=True,
+            minimum=-9,
+            maximum=0,
+            default=0,
+        )
+
+    async def set_bass(self, level: int) -> None:
+        """Mock set bass."""
+        capabilities = await self.get_bass_capabilities()
+        if level < capabilities.minimum or level > capabilities.maximum:
+            raise ValueError(
+                f"Bass level must be between {capabilities.minimum} "
+                f"and {capabilities.maximum}"
+            )
+        self._bass = level
 
     async def set_name(self, name: str) -> None:
         """Mock set name."""

--- a/apps/backend/src/opencloudtouch/devices/repository.py
+++ b/apps/backend/src/opencloudtouch/devices/repository.py
@@ -3,6 +3,7 @@ Database models and repository for device management
 Uses aiosqlite for async SQLite operations
 """
 
+import json
 import logging
 import unicodedata
 from datetime import UTC, datetime
@@ -33,6 +34,7 @@ class Device:
         ssh_permanent: bool = False,
         setup_completed_at: Optional[datetime] = None,
         marge_account_uuid: Optional[str] = None,
+        capabilities: Optional[dict[str, Any]] = None,
     ):
         self.id = id
         self.device_id = device_id
@@ -49,6 +51,7 @@ class Device:
         self.ssh_permanent = ssh_permanent
         self.setup_completed_at = setup_completed_at
         self.marge_account_uuid = marge_account_uuid
+        self.capabilities = capabilities
 
     @staticmethod
     def _extract_schema_version(firmware_version: str) -> str:
@@ -140,6 +143,11 @@ class DeviceRepository(BaseRepository):
             description="Add marge_account_uuid column to devices",
             sql="ALTER TABLE devices ADD COLUMN marge_account_uuid TEXT",
         )
+        await self._apply_migration(
+            version=104,
+            description="Add capabilities_json column to devices",
+            sql="ALTER TABLE devices ADD COLUMN capabilities_json TEXT",
+        )
 
         # Indexes
         await self._conn.execute("""
@@ -165,8 +173,8 @@ class DeviceRepository(BaseRepository):
 
         cursor = await db.execute(
             """
-            INSERT INTO devices (device_id, ip, name, model, mac_address, firmware_version, schema_version, last_seen, marge_account_uuid)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO devices (device_id, ip, name, model, mac_address, firmware_version, schema_version, last_seen, marge_account_uuid, capabilities_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(device_id) DO UPDATE SET
                 ip = excluded.ip,
                 name = excluded.name,
@@ -175,6 +183,7 @@ class DeviceRepository(BaseRepository):
                 schema_version = excluded.schema_version,
                 last_seen = excluded.last_seen,
                 marge_account_uuid = COALESCE(excluded.marge_account_uuid, devices.marge_account_uuid),
+                capabilities_json = COALESCE(excluded.capabilities_json, devices.capabilities_json),
                 updated_at = CURRENT_TIMESTAMP
             RETURNING id
         """,
@@ -188,6 +197,11 @@ class DeviceRepository(BaseRepository):
                 device.schema_version,
                 device.last_seen,
                 device.marge_account_uuid,
+                (
+                    json.dumps(device.capabilities)
+                    if device.capabilities is not None
+                    else None
+                ),
             ),
         )
 
@@ -206,7 +220,7 @@ class DeviceRepository(BaseRepository):
         cursor = await db.execute("""
             SELECT id, device_id, ip, name, model, mac_address, firmware_version,
                    schema_version, last_seen, setup_status, ssh_permanent,
-                   setup_completed_at, marge_account_uuid
+                   setup_completed_at, marge_account_uuid, capabilities_json
             FROM devices
         """)
 
@@ -225,7 +239,7 @@ class DeviceRepository(BaseRepository):
             """
             SELECT id, device_id, ip, name, model, mac_address, firmware_version,
                    schema_version, last_seen, setup_status, ssh_permanent,
-                   setup_completed_at, marge_account_uuid
+                   setup_completed_at, marge_account_uuid, capabilities_json
             FROM devices
             WHERE device_id = ?
         """,
@@ -279,7 +293,7 @@ class DeviceRepository(BaseRepository):
             """
             SELECT id, device_id, ip, name, model, mac_address, firmware_version,
                    schema_version, last_seen, setup_status, ssh_permanent,
-                   setup_completed_at, marge_account_uuid
+                   setup_completed_at, marge_account_uuid, capabilities_json
             FROM devices
             WHERE marge_account_uuid = ?
         """,
@@ -326,7 +340,7 @@ class DeviceRepository(BaseRepository):
             """
             SELECT id, device_id, ip, name, model, mac_address, firmware_version,
                    schema_version, last_seen, setup_status, ssh_permanent,
-                   setup_completed_at, marge_account_uuid
+                   setup_completed_at, marge_account_uuid, capabilities_json
             FROM devices
             WHERE marge_account_uuid = ?
         """,
@@ -380,4 +394,5 @@ class DeviceRepository(BaseRepository):
             ssh_permanent=bool(row[10]) if row[10] is not None else False,
             setup_completed_at=(datetime.fromisoformat(row[11]) if row[11] else None),
             marge_account_uuid=row[12] if len(row) > 12 else None,
+            capabilities=(json.loads(row[13]) if len(row) > 13 and row[13] else None),
         )

--- a/apps/backend/src/opencloudtouch/devices/service.py
+++ b/apps/backend/src/opencloudtouch/devices/service.py
@@ -16,7 +16,11 @@ from opencloudtouch.devices.capabilities import (
     get_capabilities_for_ip,
     get_feature_flags_for_ui,
 )
-from opencloudtouch.devices.client import NowPlayingInfo, VolumeInfo
+from opencloudtouch.devices.client import (
+    BassInfo,
+    NowPlayingInfo,
+    VolumeInfo,
+)
 from opencloudtouch.devices.events import DiscoveryEvent, DiscoveryEventType
 from opencloudtouch.devices.interfaces import (
     IDeviceRepository,
@@ -237,35 +241,44 @@ class DeviceService:
         return await self.repository.get_by_device_id(device_id)
 
     async def get_device_capabilities(self, device_id: str) -> dict:
-        """Get device capabilities for UI feature detection.
-
-        Args:
-            device_id: Device ID
-
-        Returns:
-            Feature flags and capabilities for UI rendering
-
-        Raises:
-            ValueError: If device not found
-            Exception: If device query fails
-        """
-        # Get device from DB
+        """Get persisted device capabilities for UI feature detection."""
         device = await self.repository.get_by_device_id(device_id)
-
         if not device:
             raise DeviceNotFoundError(device_id)
 
-        logger.info("Querying device capabilities")
+        if device.capabilities is not None:
+            return device.capabilities
 
+        # Backward-compatible fallback for devices stored before capability
+        # persistence was introduced. Re-discovery will persist the result.
+        logger.info("No stored capabilities for %s; querying device", device_id)
+        detected = await get_capabilities_for_ip(device.ip)
+        flags = get_feature_flags_for_ui(detected)
+
+        client = None
         try:
-            capabilities = await get_capabilities_for_ip(device.ip)
-            flags = get_feature_flags_for_ui(capabilities)
-            logger.debug("Device capabilities resolved")
-            return flags
-
+            base_url = f"http://{device.ip}:{SOUNDTOUCH_HTTP_PORT}"  # NOSONAR — Bose devices only support HTTP
+            client = await asyncio.to_thread(get_device_client, base_url)
+            bass = await client.get_bass_capabilities()
         except Exception:
-            logger.exception("Failed to get device capabilities")
-            raise
+            logger.debug(
+                "Could not fetch bass capabilities for %s",
+                device_id,
+                exc_info=True,
+            )
+        else:
+            flags.setdefault("features", {})["bass_control"] = bass.available
+            flags.setdefault("settings", {})["bass"] = {
+                "available": bass.available,
+                "minimum": bass.minimum,
+                "maximum": bass.maximum,
+                "default": bass.default,
+            }
+        finally:
+            if client is not None:
+                await client.close()
+
+        return flags
 
     @asynccontextmanager
     async def _device_client(self, device_id: str) -> AsyncIterator:
@@ -289,6 +302,29 @@ class DeviceService:
             yield client
         finally:
             await client.close()
+
+    async def get_device_bass(self, device_id: str) -> BassInfo:
+        """Get current bass state from a device."""
+        async with self._device_client(device_id) as client:
+            return await client.get_bass()
+
+    async def set_device_bass(self, device_id: str, level: int) -> None:
+        """Validate against discovered capabilities and set bass on the device."""
+        capabilities = await self.get_device_capabilities(device_id)
+        bass = capabilities.get("settings", {}).get("bass")
+
+        if not bass or not bass.get("available", False):
+            raise ValueError("Bass control is not available on this device")
+
+        minimum = bass.get("minimum")
+        maximum = bass.get("maximum")
+        if minimum is None or maximum is None:
+            raise ValueError("Bass range is not available for this device")
+        if level < minimum or level > maximum:
+            raise ValueError(f"Bass level must be between {minimum} and {maximum}")
+
+        async with self._device_client(device_id) as client:
+            await client.set_bass(level)
 
     async def press_key(self, device_id: str, key: str, state: str = "both") -> None:
         """

--- a/apps/backend/src/opencloudtouch/devices/services/sync_service.py
+++ b/apps/backend/src/opencloudtouch/devices/services/sync_service.py
@@ -9,6 +9,10 @@ from typing import TYPE_CHECKING, List, Optional
 
 from opencloudtouch.db import Device
 from opencloudtouch.devices.adapter import get_device_client, get_discovery_adapter
+from opencloudtouch.devices.capabilities import (
+    get_capabilities_for_ip,
+    get_feature_flags_for_ui,
+)
 from opencloudtouch.devices.discovery.manual import ManualDiscovery
 from opencloudtouch.devices.events import (
     device_failed_event,
@@ -320,6 +324,7 @@ class DeviceSyncService:
 
         # Fetch margeAccountUUID separately (parsed from /info XML)
         marge_uuid = await self._fetch_marge_account_uuid(discovered.ip)
+        capabilities = await self._fetch_device_capabilities(discovered.ip, client)
 
         return Device(
             device_id=info.device_id,
@@ -329,7 +334,59 @@ class DeviceSyncService:
             mac_address=info.mac_address,
             firmware_version=info.firmware_version,
             marge_account_uuid=marge_uuid,
+            capabilities=capabilities,
         )
+
+    @staticmethod
+    async def _fetch_device_capabilities(device_ip: str, client) -> Optional[dict]:
+        """Detect UI capabilities for a device during discovery.
+
+        Capability detection is best-effort: a transient failure must not prevent
+        the device itself from being discovered and persisted.
+        """
+        try:
+            if os.getenv("OCT_MOCK_MODE", "false").lower() == "true":
+                bass = await client.get_bass_capabilities()
+                return {
+                    "features": {"bass_control": bass.available},
+                    "settings": {
+                        "bass": {
+                            "available": bass.available,
+                            "minimum": bass.minimum,
+                            "maximum": bass.maximum,
+                            "default": bass.default,
+                        }
+                    },
+                }
+
+            detected = await get_capabilities_for_ip(device_ip)
+            flags = get_feature_flags_for_ui(detected)
+
+            # /bassCapabilities is authoritative. Some bosesoundtouchapi
+            # versions do not expose an IsBassCapable property at all.
+            try:
+                bass = await client.get_bass_capabilities()
+            except Exception:
+                logger.debug(
+                    "Could not fetch bass capabilities from %s",
+                    device_ip,
+                    exc_info=True,
+                )
+            else:
+                flags.setdefault("features", {})["bass_control"] = bass.available
+                flags.setdefault("settings", {})["bass"] = {
+                    "available": bass.available,
+                    "minimum": bass.minimum,
+                    "maximum": bass.maximum,
+                    "default": bass.default,
+                }
+
+            return flags
+        except Exception:
+            logger.debug(
+                "Could not detect capabilities for %s", device_ip, exc_info=True
+            )
+            return None
 
     @staticmethod
     async def _fetch_marge_account_uuid(device_ip: str) -> Optional[str]:

--- a/apps/backend/tests/integration/test_real_api_stack.py
+++ b/apps/backend/tests/integration/test_real_api_stack.py
@@ -126,6 +126,9 @@ class TestRealAPIStack:
         ) as mock_get_discovery, patch(
             "opencloudtouch.devices.services.sync_service.get_device_client"
         ) as mock_get_client, patch(
+            "opencloudtouch.devices.services.sync_service.DeviceSyncService._fetch_device_capabilities",
+            new_callable=AsyncMock,
+        ) as mock_fetch_capabilities, patch(
             "opencloudtouch.devices.api.routes.get_config"
         ) as mock_config:
 
@@ -137,6 +140,20 @@ class TestRealAPIStack:
             mock_discovery_instance = AsyncMock()
             mock_discovery_instance.discover.return_value = discovered
             mock_get_discovery.return_value = mock_discovery_instance
+
+            mock_fetch_capabilities.return_value = {
+                "features": {
+                    "bass_control": True,
+                },
+                "settings": {
+                    "bass": {
+                        "available": True,
+                        "minimum": -9,
+                        "maximum": 0,
+                        "default": 0,
+                    }
+                },
+            }
 
             # Mock client factory to return device info
             def create_mock_client(base_url, timeout=5):
@@ -167,6 +184,13 @@ class TestRealAPIStack:
         assert device_1.name == "Living Room ST30"
         assert device_1.ip == "192.168.1.100"
         assert device_1.model == "SoundTouch 30 Series III"
+        assert device_1.capabilities["features"]["bass_control"] is True
+        assert device_1.capabilities["settings"]["bass"] == {
+            "available": True,
+            "minimum": -9,
+            "maximum": 0,
+            "default": 0,
+        }
 
         device_2 = await device_repo.get_by_device_id("DDEEFF445566")
         assert device_2 is not None
@@ -268,6 +292,9 @@ class TestRealAPIStack:
         ) as mock_get_discovery, patch(
             "opencloudtouch.devices.services.sync_service.get_device_client"
         ) as mock_get_client, patch(
+            "opencloudtouch.devices.services.sync_service.DeviceSyncService._fetch_device_capabilities",
+            new_callable=AsyncMock,
+        ) as mock_fetch_capabilities, patch(
             "opencloudtouch.devices.api.routes.get_config"
         ) as mock_config:
 
@@ -278,6 +305,20 @@ class TestRealAPIStack:
             mock_discovery_instance = AsyncMock()
             mock_discovery_instance.discover.return_value = discovered_v1
             mock_get_discovery.return_value = mock_discovery_instance
+
+            mock_fetch_capabilities.return_value = {
+                "features": {
+                    "bass_control": True,
+                },
+                "settings": {
+                    "bass": {
+                        "available": True,
+                        "minimum": -9,
+                        "maximum": 0,
+                        "default": 0,
+                    }
+                },
+            }
 
             mock_client_instance = AsyncMock()
             mock_client_instance.get_info.return_value = device_info_v1
@@ -309,6 +350,9 @@ class TestRealAPIStack:
         ) as mock_get_discovery, patch(
             "opencloudtouch.devices.services.sync_service.get_device_client"
         ) as mock_get_client, patch(
+            "opencloudtouch.devices.services.sync_service.DeviceSyncService._fetch_device_capabilities",
+            new_callable=AsyncMock,
+        ) as mock_fetch_capabilities, patch(
             "opencloudtouch.devices.api.routes.get_config"
         ) as mock_config:
 
@@ -319,6 +363,20 @@ class TestRealAPIStack:
             mock_discovery_instance = AsyncMock()
             mock_discovery_instance.discover.return_value = discovered_v1
             mock_get_discovery.return_value = mock_discovery_instance
+
+            mock_fetch_capabilities.return_value = {
+                "features": {
+                    "bass_control": True,
+                },
+                "settings": {
+                    "bass": {
+                        "available": True,
+                        "minimum": -9,
+                        "maximum": 0,
+                        "default": 0,
+                    }
+                },
+            }
 
             mock_client_instance = AsyncMock()
             mock_client_instance.get_info.return_value = device_info_v2

--- a/apps/backend/tests/unit/devices/api/test_device_routes.py
+++ b/apps/backend/tests/unit/devices/api/test_device_routes.py
@@ -25,7 +25,11 @@ from opencloudtouch.core.exceptions import (
     DeviceNotFoundError,
     DomainValidationError,
 )
-from opencloudtouch.devices.client import NowPlayingInfo, VolumeInfo
+from opencloudtouch.devices.client import (
+    BassInfo,
+    NowPlayingInfo,
+    VolumeInfo,
+)
 from opencloudtouch.devices.repository import Device
 from opencloudtouch.main import app
 
@@ -181,6 +185,47 @@ class TestDeviceDetailEndpoint:
         assert device["model"] == "SoundTouch 30"
         assert device["mac_address"] == "AA:BB:CC:DD:EE:FF"
         assert device["firmware_version"] == "28.0.5.46710"
+
+
+class TestBassEndpoint:
+    """Tests for SoundTouch bass endpoints."""
+
+    def test_get_bass(self, client, mock_device_service):
+        mock_device_service.get_device_bass = AsyncMock(
+            return_value=BassInfo(actual=-2, target=-2)
+        )
+
+        response = client.get("/api/devices/ABC123/settings/bass")
+
+        assert response.status_code == 200
+        assert response.json() == {"actual": -2, "target": -2}
+        mock_device_service.get_device_bass.assert_awaited_once_with("ABC123")
+
+    def test_set_bass(self, client, mock_device_service):
+        mock_device_service.set_device_bass = AsyncMock(return_value=None)
+
+        response = client.put("/api/devices/ABC123/settings/bass", json={"level": -4})
+
+        assert response.status_code == 200
+        assert response.json()["level"] == -4
+        mock_device_service.set_device_bass.assert_awaited_once_with("ABC123", -4)
+
+    def test_set_bass_rejects_non_integer(self, client, mock_device_service):
+        response = client.put("/api/devices/ABC123/settings/bass", json={"level": "-4"})
+
+        assert response.status_code == 422
+        assert "integer" in response.json()["detail"].lower()
+        mock_device_service.set_device_bass.assert_not_called()
+
+    def test_set_bass_returns_422_for_out_of_range(self, client, mock_device_service):
+        mock_device_service.set_device_bass = AsyncMock(
+            side_effect=ValueError("Bass level must be between -9 and 0")
+        )
+
+        response = client.put("/api/devices/ABC123/settings/bass", json={"level": 1})
+
+        assert response.status_code == 422
+        assert "between -9 and 0" in response.json()["detail"]
 
 
 class TestSyncEndpoint:

--- a/apps/backend/tests/unit/devices/test_capabilities.py
+++ b/apps/backend/tests/unit/devices/test_capabilities.py
@@ -325,3 +325,46 @@ def test_supports_endpoint_with_and_without_slash():
     # Not supported
     assert capabilities.supports_endpoint("productcechdmicontrol") is False
     assert capabilities.supports_endpoint("/productcechdmicontrol") is False
+
+
+@pytest.mark.asyncio
+async def test_get_device_capabilities_supports_internal_library_fields():
+    """Support bosesoundtouchapi variants exposing internal capability/source fields."""
+    client = MagicMock()
+
+    info = MagicMock()
+    info.DeviceId = "A81B6A1DC457"
+    info.DeviceType = "SoundTouch 10"
+
+    caps = MagicMock()
+    caps.SupportedUrls = None
+    caps._Capabilities = {
+        "systemtimeout": "/systemtimeout",
+        "rebroadcastlatencymode": "/rebroadcastlatencymode",
+    }
+    caps.IsDisablePowerSavingCapable = True
+    caps.IsDualModeCapable = True
+    caps.IsLightSwitchCapable = False
+    caps.IsLrStereoCapable = True
+    caps.IsWebSocketApiProxyCapable = True
+    caps.IsBcoResetCapable = False
+    caps.IsClockDisplayCapable = False
+
+    source = MagicMock()
+    source.Source = "AUX"
+    source.Status = "READY"
+
+    sources = MagicMock()
+    sources.Sources = None
+    sources.SourceItems = None
+    sources._SourceItems = [source]
+
+    client.GetDeviceInfo.return_value = info
+    client.GetCapabilities.return_value = caps
+    client.GetSourceList.return_value = sources
+
+    result = await get_device_capabilities(client)
+
+    assert "systemtimeout" in result.supported_endpoints
+    assert "rebroadcastlatencymode" in result.supported_endpoints
+    assert "AUX" in result.supported_sources

--- a/apps/backend/tests/unit/devices/test_client_adapter.py
+++ b/apps/backend/tests/unit/devices/test_client_adapter.py
@@ -11,7 +11,12 @@ import httpx
 import pytest
 
 from opencloudtouch.core.exceptions import DeviceConnectionError
-from opencloudtouch.devices.client import DeviceInfo, NowPlayingInfo
+from opencloudtouch.devices.client import (
+    BassCapabilities,
+    BassInfo,
+    DeviceInfo,
+    NowPlayingInfo,
+)
 
 # RED: This import fails until client_adapter.py is created.
 from opencloudtouch.devices.client_adapter import BoseDeviceClientAdapter
@@ -307,3 +312,67 @@ class TestSetName:
         client = _make_client()
         with pytest.raises(DeviceConnectionError):
             await client.set_name("New Name")
+
+
+class TestBass:
+    """Tests for SoundTouch bass endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_get_bass(self, respx_mock):
+        respx_mock.get("http://192.168.1.100:8090/bass").mock(
+            return_value=httpx.Response(
+                200,
+                text=(
+                    '<bass deviceID="ABC123">'
+                    "<targetbass>-3</targetbass>"
+                    "<actualbass>-3</actualbass>"
+                    "</bass>"
+                ),
+            )
+        )
+
+        client = _make_client()
+        result = await client.get_bass()
+
+        assert isinstance(result, BassInfo)
+        assert result.target == -3
+        assert result.actual == -3
+
+    @pytest.mark.asyncio
+    async def test_get_bass_capabilities(self, respx_mock):
+        respx_mock.get("http://192.168.1.100:8090/bassCapabilities").mock(
+            return_value=httpx.Response(
+                200,
+                text=(
+                    '<bassCapabilities deviceID="ABC123">'
+                    "<bassAvailable>true</bassAvailable>"
+                    "<bassMin>-9</bassMin>"
+                    "<bassMax>0</bassMax>"
+                    "<bassDefault>0</bassDefault>"
+                    "</bassCapabilities>"
+                ),
+            )
+        )
+
+        client = _make_client()
+        result = await client.get_bass_capabilities()
+
+        assert isinstance(result, BassCapabilities)
+        assert result.available is True
+        assert result.minimum == -9
+        assert result.maximum == 0
+        assert result.default == 0
+
+    @pytest.mark.asyncio
+    async def test_set_bass_posts_xml(self, respx_mock):
+        respx_mock.post("http://192.168.1.100:8090/bass").mock(
+            return_value=httpx.Response(200)
+        )
+
+        client = _make_client()
+        await client.set_bass(-4)
+
+        request = respx_mock.calls[-1].request
+        assert request.method == "POST"
+        assert request.url.path == "/bass"
+        assert b"<bass>-4</bass>" in request.content

--- a/apps/backend/tests/unit/devices/test_device_service.py
+++ b/apps/backend/tests/unit/devices/test_device_service.py
@@ -9,7 +9,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from opencloudtouch.core.exceptions import DeviceNotFoundError, DomainValidationError
-from opencloudtouch.devices.client import NowPlayingInfo, VolumeInfo
+from opencloudtouch.devices.capabilities import DeviceCapabilities
+from opencloudtouch.devices.client import (
+    BassCapabilities,
+    BassInfo,
+    NowPlayingInfo,
+    VolumeInfo,
+)
 from opencloudtouch.devices.models import KeyType, SyncResult
 from opencloudtouch.devices.repository import Device
 from opencloudtouch.devices.service import DeviceService
@@ -230,11 +236,13 @@ class TestDeviceServiceCapabilities:
         # Arrange
         mock_repository.get_by_device_id.return_value = sample_device
 
-        expected_capabilities = {
-            "model": "SoundTouch 30 Series III",
-            "api_version": "1.0",
-            "has_hdmi": False,
-        }
+        expected_capabilities = DeviceCapabilities(
+            device_id="AABBCC112233",
+            device_type="SoundTouch 30 Series III",
+            has_hdmi_control=False,
+            has_bass_control=True,
+            has_bluetooth=True,
+        )
 
         expected_feature_flags = {
             "device_id": "AABBCC112233",
@@ -247,13 +255,24 @@ class TestDeviceServiceCapabilities:
             },
         }
 
-        # Mock the capability detection and device client creation
+        mock_client = AsyncMock()
+        mock_client.get_bass_capabilities.return_value = BassCapabilities(
+            available=True,
+            minimum=-9,
+            maximum=0,
+            default=0,
+        )
+
+        # Mock capability detection and device communication.
         with patch(
             "opencloudtouch.devices.service.get_capabilities_for_ip",
             new_callable=AsyncMock,
         ) as mock_get_caps, patch(
             "opencloudtouch.devices.service.get_feature_flags_for_ui"
-        ) as mock_get_flags:
+        ) as mock_get_flags, patch(
+            "opencloudtouch.devices.service.get_device_client",
+            return_value=mock_client,
+        ):
 
             mock_get_caps.return_value = expected_capabilities
             mock_get_flags.return_value = expected_feature_flags
@@ -279,6 +298,53 @@ class TestDeviceServiceCapabilities:
         # Act & Assert
         with pytest.raises(DeviceNotFoundError):
             await device_service.get_device_capabilities("NONEXISTENT")
+
+
+class TestDeviceServiceBass:
+    """Test device bass operations."""
+
+    @pytest.mark.asyncio
+    async def test_get_device_bass(
+        self, device_service, mock_repository, sample_device
+    ):
+        mock_repository.get_by_device_id.return_value = sample_device
+        mock_client = AsyncMock()
+        mock_client.get_bass.return_value = BassInfo(actual=-3, target=-3)
+
+        with patch(
+            "opencloudtouch.devices.service.get_device_client",
+            return_value=mock_client,
+        ):
+            result = await device_service.get_device_bass(sample_device.device_id)
+
+        assert result == BassInfo(actual=-3, target=-3)
+        mock_client.get_bass.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_set_device_bass(
+        self, device_service, mock_repository, sample_device
+    ):
+        sample_device.capabilities = {
+            "features": {"bass_control": True},
+            "settings": {
+                "bass": {
+                    "available": True,
+                    "minimum": -9,
+                    "maximum": 0,
+                    "default": 0,
+                }
+            },
+        }
+        mock_repository.get_by_device_id.return_value = sample_device
+        mock_client = AsyncMock()
+
+        with patch(
+            "opencloudtouch.devices.service.get_device_client",
+            return_value=mock_client,
+        ):
+            await device_service.set_device_bass(sample_device.device_id, -4)
+
+        mock_client.set_bass.assert_awaited_once_with(-4)
 
 
 class TestDeviceServiceSendKey:

--- a/apps/backend/tests/unit/devices/test_mock_client.py
+++ b/apps/backend/tests/unit/devices/test_mock_client.py
@@ -4,7 +4,13 @@ Tests for MockDeviceClient.
 
 import pytest
 
-from opencloudtouch.devices.client import DeviceInfo, NowPlayingInfo, VolumeInfo
+from opencloudtouch.devices.client import (
+    BassCapabilities,
+    BassInfo,
+    DeviceInfo,
+    NowPlayingInfo,
+    VolumeInfo,
+)
 from opencloudtouch.devices.mock_client import MockDeviceClient
 
 
@@ -177,3 +183,42 @@ class TestMockDeviceClientVolume:
         vol = await client.get_volume()
 
         assert vol.muted is False
+
+
+class TestMockDeviceClientBass:
+    """Tests for mock device bass control."""
+
+    @pytest.mark.asyncio
+    async def test_get_bass_default(self):
+        client = MockDeviceClient(device_id="AABBCC112233")
+        bass = await client.get_bass()
+
+        assert isinstance(bass, BassInfo)
+        assert bass.actual == 0
+        assert bass.target == 0
+
+    @pytest.mark.asyncio
+    async def test_get_bass_capabilities(self):
+        client = MockDeviceClient(device_id="AABBCC112233")
+        caps = await client.get_bass_capabilities()
+
+        assert isinstance(caps, BassCapabilities)
+        assert caps.available is True
+        assert caps.minimum == -9
+        assert caps.maximum == 0
+        assert caps.default == 0
+
+    @pytest.mark.asyncio
+    async def test_set_bass(self):
+        client = MockDeviceClient(device_id="AABBCC112233")
+        await client.set_bass(-5)
+        bass = await client.get_bass()
+
+        assert bass.actual == -5
+        assert bass.target == -5
+
+    @pytest.mark.asyncio
+    async def test_set_bass_rejects_out_of_range(self):
+        client = MockDeviceClient(device_id="AABBCC112233")
+        with pytest.raises(ValueError, match="between -9 and 0"):
+            await client.set_bass(-10)

--- a/apps/backend/tests/unit/devices/test_service.py
+++ b/apps/backend/tests/unit/devices/test_service.py
@@ -180,9 +180,17 @@ class TestGetDeviceCapabilities:
     @pytest.mark.asyncio
     async def test_returns_flags(self):
         repo = AsyncMock()
-        repo.get_by_device_id.return_value = _make_device()
+        device = _make_device()
+        device.capabilities = None
+        repo.get_by_device_id.return_value = device
 
         svc = _make_service(repo=repo)
+
+        mock_client = AsyncMock()
+        mock_client.get_bass_capabilities.side_effect = ConnectionError(
+            "bass capabilities unavailable"
+        )
+
         with (
             patch(
                 "opencloudtouch.devices.service.get_capabilities_for_ip",
@@ -192,6 +200,10 @@ class TestGetDeviceCapabilities:
             patch(
                 "opencloudtouch.devices.service.get_feature_flags_for_ui",
                 return_value={"aux": True},
+            ),
+            patch(
+                "opencloudtouch.devices.service.get_device_client",
+                return_value=mock_client,
             ),
         ):
             result = await svc.get_device_capabilities("D1")
@@ -209,7 +221,9 @@ class TestGetDeviceCapabilities:
     @pytest.mark.asyncio
     async def test_propagates_capability_error(self):
         repo = AsyncMock()
-        repo.get_by_device_id.return_value = _make_device()
+        device = _make_device()
+        device.capabilities = None
+        repo.get_by_device_id.return_value = device
 
         svc = _make_service(repo=repo)
         with patch(

--- a/apps/backend/tests/unit/devices/test_sync_service.py
+++ b/apps/backend/tests/unit/devices/test_sync_service.py
@@ -39,6 +39,38 @@ def mock_device_info():
     return info
 
 
+@pytest.fixture(autouse=True)
+def mock_device_metadata_queries(monkeypatch):
+    """Keep sync unit tests isolated from real SoundTouch network calls."""
+
+    async def mock_fetch_capabilities(device_ip, client):
+        return {
+            "features": {"bass_control": True},
+            "settings": {
+                "bass": {
+                    "available": True,
+                    "minimum": -9,
+                    "maximum": 0,
+                    "default": 0,
+                }
+            },
+        }
+
+    async def mock_fetch_marge_uuid(device_ip):
+        return None
+
+    monkeypatch.setattr(
+        DeviceSyncService,
+        "_fetch_device_capabilities",
+        staticmethod(mock_fetch_capabilities),
+    )
+    monkeypatch.setattr(
+        DeviceSyncService,
+        "_fetch_marge_account_uuid",
+        staticmethod(mock_fetch_marge_uuid),
+    )
+
+
 class TestDeviceSyncService:
     """Test suite for DeviceSyncService."""
 


### PR DESCRIPTION
## Summary

This PR implements the backend foundation for Bass control as a focused first part of #325 (`feat: expose device capabilities and settings (clock, bass, bluetooth, power save)`).

It also builds on the experimental device-settings work contributed by @Zimbo88 and tracked in #247.

Zimbo88's experimental patch series demonstrated Bass reduction, clock/display settings, power standby options and other device settings on real SoundTouch devices. For this PR, the Bass part was used as a starting point for investigation and testing, then reworked against the current OCT codebase and aligned with the capability-based architecture proposed in #325.

Many thanks to @Zimbo88 for the extensive experimental work and real-device testing.

Related to #247 and #325


## What this PR adds

- Bass capability detection per device via `/bassCapabilities`
- persistence of detected device capabilities in the OCT database
- capability refresh during device re-discovery / synchronization
- Bass metadata in the existing per-device capability API
- `GET /api/devices/{device_id}/settings/bass`
- `PUT /api/devices/{device_id}/settings/bass`
- validation against the device-reported Bass range
- OpenAPI, mock client, service, repository, sync and API tests

The existing capability endpoint remains:

`GET /api/devices/{device_id}/capabilities`

For a Bass-capable device, capability data can include:

{
  "features": {
    "bass_control": true
  },
  "settings": {
    "bass": {
      "available": true,
      "minimum": -9,
      "maximum": 0,
      "default": 0
    }
  }
}


## Persistence model

Only device capabilities are stored in the OCT database.

The currently selected Bass value is not duplicated in OCT. The SoundTouch device remains the source of truth and the current value is read live from the device.

This avoids maintaining a second potentially stale settings state.

Capability information is refreshed when the device is discovered/synchronized again.


## Compatibility

Bass support is detected directly through `/bassCapabilities` instead of relying on a generic `IsBassCapable` property.

During real-device testing, the tested SoundTouch 10 supported `/bassCapabilities`, while the capability object exposed by the current SoundTouch API library did not expose `IsBassCapable`.

Capability discovery was also made more defensive for library representations such as `_Capabilities` and `_SourceItems`.

A regression test was added for bosesoundtouchapi variants exposing these internal fields.


## Testing

Tested with a real Bose SoundTouch 10.

Verified:

- discovery / probe
- Bass capability detection
- capability persistence per device
- existing `/capabilities` API returning Bass support
- live Bass read
- Bass write
- reset to `0`
- device-reported range `-9 ... 0`
- values outside the supported range return `422`
- re-discovery / synchronization with persisted capabilities
- regression coverage for `_Capabilities` / `_SourceItems` library variants

Backend test suite:

`2254 passed, 5 deselected`

The external TuneIn live test was excluded because it depends on external DNS/network availability.

Ruff and Bandit checks also passed. The new XML parsing uses the project's existing `defusedxml` dependency.


## Follow-up / extension

This PR intentionally implements Bass only.

Clock, Power Save, Bluetooth and other device-specific settings can follow the same pattern:

1. add client methods
2. implement the SoundTouch API call
3. add mock behavior
4. detect support per device
5. persist capability metadata
6. add service/API methods
7. document in OpenAPI
8. add tests

The frontend can use `/api/devices/{device_id}/capabilities` to show only settings supported by the selected device.

This fits the device-aware UI proposed in #325, for example a settings icon in DeviceSwiper that opens settings for the current device.