### PR TITLE
fix(devices): handle empty cached now playing state

### DIFF
--- a/apps/backend/src/opencloudtouch/devices/api/routes.py
+++ b/apps/backend/src/opencloudtouch/devices/api/routes.py
@@ -511,7 +511,11 @@ async def get_now_playing(
             # Offline devices are expected, not exceptional: return the last
             # known state (if any) instead of a 503 that just spams the
             # poller's browser console every cycle (#319).
-            fallback = cached.now_playing if cached else _OFFLINE_FALLBACK_INFO
+            fallback = (
+                cached.now_playing
+                if cached and cached.now_playing
+                else _OFFLINE_FALLBACK_INFO
+            )
             return _now_playing_to_dict(fallback, online=False)
     result = _now_playing_to_dict(info, online=True)
 

--- a/apps/backend/tests/unit/devices/api/test_device_routes.py
+++ b/apps/backend/tests/unit/devices/api/test_device_routes.py
@@ -991,6 +991,28 @@ class TestNowPlayingEndpoint:
         assert data["online"] is False
         assert data["station_name"] == "Jazz FM"
 
+    def test_get_now_playing_offline_device_with_empty_cached_state_returns_200(
+        self, client, mock_device_service
+    ):
+        """An existing cached state without now-playing data must fall back cleanly."""
+        from opencloudtouch.core.dependencies import get_device_state_manager
+        from opencloudtouch.devices.websocket.connection import ConnectionState
+
+        state_manager = client.app.dependency_overrides[get_device_state_manager]()
+        state_manager.update_connection("DEV123", ConnectionState.DISCONNECTED)
+
+        mock_device_service.get_now_playing = AsyncMock(
+            side_effect=DeviceConnectionError("192.168.1.50", "Connection refused")
+        )
+
+        response = client.get("/api/devices/DEV123/now-playing")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["online"] is False
+        assert data["source"] == ""
+        assert data["station_name"] is None
+
     def test_get_now_playing_offline_device_without_cache_still_returns_200(
         self, client, mock_device_service
     ):


### PR DESCRIPTION
## Summary

Fixes a Now Playing offline fallback edge case where a cached device state can exist while `cached.now_playing` is still `None`.

In that situation, if the live Now Playing request fails with `DeviceConnectionError`, the route could pass `None` to `_now_playing_to_dict()`, resulting in an `AttributeError` instead of returning the intended graceful offline response.

## How this was found

While working on #432, the local pre-push MyPy check reported an unrelated type error in the existing Now Playing route.

The same MyPy error was reproduced on an untouched `upstream/main`, confirming it was unrelated to the Bass changes.

Further investigation showed that `DeviceState` can legitimately exist with `now_playing=None`, for example after a connection-state update before any Now Playing event has been received.

## Fix

Fall back to `_OFFLINE_FALLBACK_INFO` when either:

- no cached state exists, or
- a cached state exists but contains no Now Playing information.

## Testing

- Added regression coverage for an existing cached state with `now_playing=None`
- Now Playing API route tests: `54 passed`
- MyPy for `src/opencloudtouch/devices/api/routes.py`: `Success: no issues found in 1 source file`