### PR TITLE
ci: fix fork-PR comment 403 via workflow_run relay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,9 +653,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [mojibake-check, test-page-size-detection, commit-lint, security, license-check, lint, backend-tests, frontend-tests, e2e-tests]
     if: always()
-    permissions:
-      pull-requests: write
-      issues: write
 
     steps:
       - name: Download backend coverage
@@ -715,11 +712,12 @@ jobs:
             exit 1
           fi
 
-      - name: Post CI summary as PR comment
-        if: github.event_name == 'pull_request'
+      - name: Save PR summary comment payload
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |
+            const fs = require('fs');
             const statusIcon = (result) => result === 'success' ? '✅' : result === 'skipped' ? '⏭️' : '❌';
             const jobs = [
               ['Mojibake Check', '${{ needs.mojibake-check.result }}'],
@@ -744,32 +742,23 @@ jobs:
             }
             body += `\n🔗 [Full details](${context.payload.pull_request.html_url}/checks)\n`;
 
-            // Use sticky comment (update existing instead of spamming)
             const marker = '<!-- ci-summary -->';
             body = marker + '\n' + body;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(marker));
+            fs.mkdirSync('.pr-comment', { recursive: true });
+            fs.writeFileSync('.pr-comment/summary.json', JSON.stringify({
+              pr_number: context.issue.number,
+              marker,
+              body,
+            }));
 
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body,
-              });
-            }
+      - name: Upload PR comment payload
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-comment-summary
+          path: .pr-comment/summary.json
+          retention-days: 1
 
   # ============================================================================
   # AUTO-FORMAT (runs at the end — commits formatting fixes back to branch)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,6 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -196,16 +195,15 @@ jobs:
           echo ""
           echo "✅ All commits follow Conventional Commits format!"
 
-      - name: PR comment on failure
+      - name: Save PR comment payload on failure
         if: failure()
         uses: actions/github-script@v9
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## ❌ Commit Message Validation Failed
+            const fs = require('fs');
+            const marker = '<!-- commit-lint-check -->';
+            const body = `${marker}
+            ## ❌ Commit Message Validation Failed
 
             Your PR contains commits that don't follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
 
@@ -223,8 +221,21 @@ jobs:
             \`feat\`, \`fix\`, \`docs\`, \`style\`, \`refactor\`, \`perf\`, \`test\`, \`build\`, \`ci\`, \`chore\`, \`revert\`
 
             📖 See [Conventional Commits](https://www.conventionalcommits.org/) for details.
-            `,
-            });
+            `;
+            fs.mkdirSync('.pr-comment', { recursive: true });
+            fs.writeFileSync('.pr-comment/commit-lint.json', JSON.stringify({
+              pr_number: context.issue.number,
+              marker,
+              body,
+            }));
+
+      - name: Upload PR comment payload
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-comment-commit-lint
+          path: .pr-comment/commit-lint.json
+          retention-days: 1
 
   # ============================================================================
   # SECURITY SCANNING

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -10,6 +10,19 @@
 # forces on `pull_request`-triggered runs from forks. This workflow never
 # checks out or runs any code from the PR; it only reads the small JSON
 # payloads that ci.yml's own trusted jobs already staged as artifacts.
+#
+# IMPORTANT: for a `pull_request` run from a fork, GitHub executes the FORK'S
+# OWN COPY of ci.yml — so the `pr_number` inside a staged JSON payload is
+# attacker-influenced, not trustworthy. This workflow never uses it to decide
+# which PR to comment on: the target PR is always resolved independently from
+# the trusted `workflow_run` event (via `pull_requests`, or a commit-SHA
+# lookup when that's empty, as it is for fork PRs). Without this, a fork PR
+# could redirect this workflow's real write access at an arbitrary PR.
+#
+# Trade-off: this relay applies uniformly to same-repo and fork PRs alike
+# (there's no safe way to keep the old direct-post path for one and not the
+# other), so every PR now waits for a second workflow run before the sticky
+# comment appears/updates, not just fork PRs. This is expected, not a bug.
 # ==============================================================================
 
 name: PR Comment Relay
@@ -30,7 +43,7 @@ jobs:
       github.event.workflow_run.conclusion != 'cancelled'
     permissions:
       actions: read
-      pull-requests: write
+      pull-requests: read
       issues: write
 
     steps:
@@ -50,6 +63,32 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+
+            // Resolve which PR this run belongs to from the trusted
+            // workflow_run event — never from the artifact payload. For a
+            // fork PR, ci.yml ran with the fork's own copy of the workflow
+            // file, so anything the payload claims (including pr_number) is
+            // attacker-influenced.
+            const runPRs = context.payload.workflow_run.pull_requests || [];
+            let issueNumber;
+            if (runPRs.length > 0) {
+              issueNumber = runPRs[0].number;
+            } else {
+              // Empty for fork-originated runs — resolve via the commit SHA.
+              const headSha = context.payload.workflow_run.head_sha;
+              const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+              });
+              const openPulls = pulls.filter(p => p.state === 'open');
+              if (openPulls.length === 0) {
+                console.log(`No open PR found for commit ${headSha} — nothing to comment on.`);
+                return;
+              }
+              issueNumber = openPulls[0].number;
+            }
+
             const dir = './pr-comment-payloads';
 
             if (!fs.existsSync(dir)) {
@@ -65,10 +104,14 @@ jobs:
 
             for (const file of files) {
               const payload = JSON.parse(fs.readFileSync(`${dir}/${file}`, 'utf8'));
-              const { pr_number: issueNumber, marker, body } = payload;
+              const { marker, body } = payload;
 
-              if (!issueNumber || !marker || !body) {
-                console.log(`Skipping ${file}: missing pr_number, marker, or body.`);
+              if (payload.pr_number && payload.pr_number !== issueNumber) {
+                console.log(`WARNING: ${file} claimed pr_number ${payload.pr_number} but this run belongs to PR #${issueNumber} — ignoring the claimed value.`);
+              }
+
+              if (!marker || !body) {
+                console.log(`Skipping ${file}: missing marker or body.`);
                 continue;
               }
 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,99 @@
+# ==============================================================================
+# PR COMMENT RELAY
+#
+# Posts/updates the sticky PR comments (CI summary, commit-lint failure) that
+# ci.yml's jobs stage as JSON artifacts instead of posting directly.
+#
+# Runs via `workflow_run`, which always executes using this file and the
+# default GITHUB_TOKEN permissions of the base repository (main) — never the
+# fork's copy of the workflow, and never with the read-only token GitHub
+# forces on `pull_request`-triggered runs from forks. This workflow never
+# checks out or runs any code from the PR; it only reads the small JSON
+# payloads that ci.yml's own trusted jobs already staged as artifacts.
+# ==============================================================================
+
+name: PR Comment Relay
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  post-comments:
+    name: Post staged PR comments
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      actions: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Download staged comment payloads
+        uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: pr-comment-*
+          merge-multiple: true
+          path: ./pr-comment-payloads
+          if-no-artifact-found: ignore
+
+      - name: Post or update sticky comments
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const dir = './pr-comment-payloads';
+
+            if (!fs.existsSync(dir)) {
+              console.log('No staged PR comment payloads found — nothing to do.');
+              return;
+            }
+
+            const files = fs.readdirSync(dir).filter(f => f.endsWith('.json'));
+            if (files.length === 0) {
+              console.log('No staged PR comment payloads found — nothing to do.');
+              return;
+            }
+
+            for (const file of files) {
+              const payload = JSON.parse(fs.readFileSync(`${dir}/${file}`, 'utf8'));
+              const { pr_number: issueNumber, marker, body } = payload;
+
+              if (!issueNumber || !marker || !body) {
+                console.log(`Skipping ${file}: missing pr_number, marker, or body.`);
+                continue;
+              }
+
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              const existing = comments.find(c => c.body.includes(marker));
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                console.log(`Updated comment ${existing.id} on PR #${issueNumber} (${marker}).`);
+              } else {
+                const { data: created } = await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body,
+                });
+                console.log(`Created comment ${created.id} on PR #${issueNumber} (${marker}).`);
+              }
+            }


### PR DESCRIPTION
## Summary
- `ci.yml`'s summary/commit-lint jobs no longer call the GitHub API directly to post PR comments — GitHub downgrades `GITHUB_TOKEN` to read-only for `pull_request` runs from forks regardless of declared `permissions:`, which was causing `403 Resource not accessible by integration` (see run 32856911178 / PR #433).
- Both jobs now stage the comment body as a small JSON artifact (`pr-comment-*`).
- New `pr-comment.yml` workflow, triggered by `workflow_run` on CI completion, downloads those artifacts and posts/updates the sticky PR comments. `workflow_run` always executes with the base repo's own workflow file and default token permissions, so this works uniformly for same-repo and fork PRs — and it never checks out or runs any PR/fork code.
- Bonus fix: the CI summary comment step previously lacked `if: always()`, so it was silently skipped whenever the "Fail if any core job failed" step exited 1 — meaning the "❌ CI Failed" comment never actually posted on a genuine failure. Fixed as part of this move.

## Test plan
- [x] YAML syntax validated for both modified/new workflow files (`python -c "import yaml; yaml.safe_load(...)"`)
- [ ] This PR's own `CI` run completes and uploads `pr-comment-*` artifacts without a 403
- [ ] `PR Comment Relay` run fires via `workflow_run` after `CI` completes and posts the sticky `<!-- ci-summary -->` comment on this PR
- [ ] A follow-up commit updates the same comment in place (no duplicate)
- [ ] Confirm with a real fork PR (e.g. re-run/rebase of #433) that the 403 is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)