### PR TITLE
fix(entrypoint): handle supported page sizes correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
                 exit 1
               fi
             else
-              if echo "$OUTPUT" | grep -q "byte pages which is not supported"; then
+              if echo "$OUTPUT" | grep -q "page size, which is not supported"; then
                 echo "ERROR: Page size check unexpectedly rejected value '$VALUE'"
                 exit 1
               fi
@@ -115,7 +115,9 @@ jobs:
           }
 
           run_page_size_test "4096" false "" "4KB page size accepted"
-          run_page_size_test "32768" true "32768-byte pages" "32KB page size rejected"
+          run_page_size_test "16384" false "" "16KB page size accepted"
+          run_page_size_test "32768" true "32768-byte page size" "32KB page size rejected"
+          run_page_size_test "65536" false "has not been fully validated with this page size" "64KB page size allowed with warning"
           run_page_size_test "" false "Unable to determine system page size" "Empty page size handled with warning"
           run_page_size_test "abc" false "Unable to determine system page size" "Non-numeric page size handled with warning"
 

--- a/apps/backend/entrypoint.sh
+++ b/apps/backend/entrypoint.sh
@@ -31,12 +31,19 @@ check_page_size() {
         return 0
     fi
 
-    if [ "$PAGE_SIZE" -gt 4096 ]; then
-        log_error "This platform uses ${PAGE_SIZE}-byte pages which is not supported by Python/Docker."
-        log_error "Supported platforms: Standard Linux (4KB pages), Raspberry Pi, x86/x64."
-        log_error "Unsupported: QNAP ARM NAS (32KB pages)."
+    # 16KB pages are the default on Raspberry Pi 5 systems using the
+    # optimized kernel, and users have reported OpenCloudTouch working
+    # successfully with this page size.
+    if [ "$PAGE_SIZE" -eq 32768 ]; then
+        log_error "This platform uses a 32768-byte page size, which is not supported."
+        log_error "Affected platforms include QNAP ARM NAS systems using 32KB pages."
         log_error "See: https://www.qnap.com/en-uk/how-to/faq/article/why-do-the-installed-third-party-containers-not-run-successfully-on-specific-32-bit-arm-devices"
         exit 1
+    fi
+
+    if [ "$PAGE_SIZE" -eq 65536 ]; then
+        log_warn "This platform uses a 65536-byte page size."
+        log_warn "OpenCloudTouch has not been fully validated with this page size; startup will continue."
     fi
 }
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced by the page-size compatibility check in #426.

The current check rejects every page size greater than 4KB. This also blocks Raspberry Pi 5 systems using the standard 16KB page size, even though OpenCloudTouch works on these systems.

This has now been reported independently in #435 and #448. In both reports, users confirmed that OpenCloudTouch v1.5.6 worked on the same systems, while v1.5.7 is rejected during entrypoint startup because of the page-size check.

## Changes

- Allow 4KB page sizes as before
- Allow 16KB page sizes
  - 16KB is used by the optimized Raspberry Pi 5 kernel
  - users have reported OpenCloudTouch working successfully with this page size
- Reject only the known problematic 32KB page size
- Allow 64KB page sizes, but log a warning because this configuration has not yet been fully validated with OpenCloudTouch
- Keep the existing warning and continue startup if the page size cannot be determined
- Extend the CI regression test to cover 4KB, 16KB, 32KB and 64KB page sizes

## Result

Expected behavior after this change:

| Page size | Behavior |
|-----------|----------|
| 4KB | Continue normally |
| 16KB | Continue normally |
| 32KB | Stop startup with an error |
| 64KB | Continue with a warning |
| Unknown / invalid | Continue with a warning |

The 32KB protection remains in place for the known ARM/QNAP compatibility case, while working Raspberry Pi 5 installations are no longer blocked.

Fixes #435
Fixes #448

Related: #346, #426