### PR TITLE
feat(zones): hard-delete dissolved zones

### DIFF
--- a/apps/backend/src/opencloudtouch/zones/repository.py
+++ b/apps/backend/src/opencloudtouch/zones/repository.py
@@ -113,6 +113,24 @@ class ZoneRepository(BaseRepository):
             sql="CREATE INDEX IF NOT EXISTS idx_zone_members_device ON zone_members(device_id)",
         )
 
+        await self._apply_migration(
+            version=205,
+            description="Delete members of previously dissolved zones",
+            sql="""
+                DELETE FROM zone_members
+                WHERE zone_id IN (
+                    SELECT id
+                    FROM zones
+                    WHERE dissolved_at IS NOT NULL
+                )
+            """,
+        )
+        await self._apply_migration(
+            version=206,
+            description="Delete previously dissolved zones",
+            sql="DELETE FROM zones WHERE dissolved_at IS NOT NULL",
+        )
+
         await self._conn.commit()
 
     async def create_zone(self, master_device_id: str) -> Zone:
@@ -182,29 +200,20 @@ class ZoneRepository(BaseRepository):
         logger.debug("Removed %s from zone %d", device_id, zone_id)
 
     async def dissolve_zone(self, zone_id: int) -> None:
-        """Dissolve a zone (soft delete)."""
+        """Dissolve a zone by permanently deleting it and its members."""
         db = self._ensure_initialized()
 
-        now = datetime.now(UTC)
-
-        # Mark zone as dissolved
         await db.execute(
-            "UPDATE zones SET dissolved_at = ? WHERE id = ? AND dissolved_at IS NULL",
-            (now, zone_id),
+            "DELETE FROM zone_members WHERE zone_id = ?",
+            (zone_id,),
         )
-
-        # Remove all members
         await db.execute(
-            """
-            UPDATE zone_members
-            SET removed_at = ?
-            WHERE zone_id = ? AND removed_at IS NULL
-            """,
-            (now, zone_id),
+            "DELETE FROM zones WHERE id = ?",
+            (zone_id,),
         )
-
         await db.commit()
-        logger.info("Dissolved zone %d", zone_id)
+
+        logger.info("Dissolved and deleted zone %d", zone_id)
 
     async def get_active_zone_by_master(self, master_device_id: str) -> Optional[Zone]:
         """Get active zone by master device ID."""

--- a/apps/backend/src/opencloudtouch/zones/service.py
+++ b/apps/backend/src/opencloudtouch/zones/service.py
@@ -254,7 +254,7 @@ class ZoneService:
             logger.warning(
                 "No zone found for master_id=%s, nothing to dissolve", master_id
             )
-            # Still update DB to mark as dissolved
+            # Remove stale zone from database
             zone_db = await self.zone_repo.get_active_zone_by_master(master.device_id)
             if zone_db and zone_db.id is not None:
                 await self.zone_repo.dissolve_zone(zone_db.id)
@@ -276,12 +276,12 @@ class ZoneService:
                 master_id,
             )
         finally:
-            # Update database ALWAYS (even if remove_zone() threw exception)
+            # Remove database entry ALWAYS (even if remove_zone() threw exception)
             # Physical zone state is source of truth (WebSocket events)
             zone_db = await self.zone_repo.get_active_zone_by_master(master.device_id)
             if zone_db and zone_db.id is not None:
                 await self.zone_repo.dissolve_zone(zone_db.id)
-                logger.info("Zone marked as dissolved in DB (zone_id=%d)", zone_db.id)
+                logger.info("Zone removed from DB (zone_id=%d)", zone_db.id)
 
     async def change_master(self, old_master_id: str, new_master_id: str) -> ZoneStatus:
         """Change the master of a zone. Dissolve old, recreate with new master."""

--- a/apps/backend/tests/unit/devices/test_health_check.py
+++ b/apps/backend/tests/unit/devices/test_health_check.py
@@ -730,27 +730,57 @@ class TestZoneSyncAll:
 
         mock_zone_repo.dissolve_zone.assert_not_called()
 
-    async def test_device_reports_no_zone_dissolves_in_db(
-        self, zone_health_check, mock_repo, mock_zone_repo
+    async def test_device_reports_no_zone_hard_deletes_from_db(
+        self, mock_repo, tmp_path
     ):
-        """Device reports no zone → dissolve_zone() called after grace period."""
+        """Device reporting no zone hard-deletes DB rows after grace period."""
         from opencloudtouch.devices.health_check import ZONE_FAIL_THRESHOLD
+        from opencloudtouch.zones.repository import ZoneRepository
 
-        zone = self._make_zone(zone_id=42)
-        mock_zone_repo.get_all_active_zones.return_value = [zone]
-        mock_repo.get_by_device_id.return_value = _make_device()
+        zone_repo = ZoneRepository(tmp_path / "zones.db")
+        await zone_repo.initialize()
 
-        mock_client = AsyncMock()
-        mock_client.get_zone_status.return_value = None
+        try:
+            zone = await zone_repo.create_zone("dev1")
+            assert zone.id is not None
+            await zone_repo.add_member(zone.id, "dev2", "slave")
 
-        with patch(
-            "opencloudtouch.devices.adapter.get_device_client",
-            return_value=mock_client,
-        ):
-            for _ in range(ZONE_FAIL_THRESHOLD):
-                await zone_health_check._zone_sync_all()
+            mock_repo.get_by_device_id.return_value = _make_device(
+                device_id="dev1"
+            )
 
-        mock_zone_repo.dissolve_zone.assert_called_once_with(42)
+            mock_client = AsyncMock()
+            mock_client.get_zone_status.return_value = None
+
+            health_check = DeviceHealthCheck(
+                mock_repo,
+                zone_repo=zone_repo,
+            )
+
+            with patch(
+                "opencloudtouch.devices.adapter.get_device_client",
+                return_value=mock_client,
+            ):
+                for _ in range(ZONE_FAIL_THRESHOLD):
+                    await health_check._zone_sync_all()
+
+            db = zone_repo._ensure_initialized()
+
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM zones WHERE id = ?",
+                (zone.id,),
+            )
+            assert (await cursor.fetchone())[0] == 0
+
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM zone_members WHERE zone_id = ?",
+                (zone.id,),
+            )
+            assert (await cursor.fetchone())[0] == 0
+
+            assert zone.id not in health_check._zone_fail_count
+        finally:
+            await zone_repo.close()
 
     async def test_members_match_no_update(
         self, zone_health_check, mock_repo, mock_zone_repo

--- a/apps/backend/tests/unit/zones/test_zone_repository.py
+++ b/apps/backend/tests/unit/zones/test_zone_repository.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from opencloudtouch.devices.repository import Device, DeviceRepository
 from opencloudtouch.zones.repository import ZoneRepository
 
 
@@ -50,18 +51,189 @@ class TestZoneRepository:
         assert len(members) == 1  # Only master left
         assert members[0].device_id == "MASTER_001"
 
-    async def test_dissolve_zone(self, repo):
-        """Dissolve a zone (soft delete)."""
+    async def test_dissolve_zone_hard_deletes_zone_and_members(self, repo):
+        """Dissolving a zone permanently deletes the zone and its members."""
         zone = await repo.create_zone("MASTER_001")
         await repo.add_member(zone.id, "SLAVE_001", "slave")
 
         await repo.dissolve_zone(zone.id)
 
-        active_zones = await repo.get_all_active_zones()
-        assert len(active_zones) == 0
+        db = repo._ensure_initialized()
 
-        members = await repo.get_active_members(zone.id)
-        assert len(members) == 0
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM zones WHERE id = ?",
+            (zone.id,),
+        )
+        assert (await cursor.fetchone())[0] == 0
+
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM zone_members WHERE zone_id = ?",
+            (zone.id,),
+        )
+        assert (await cursor.fetchone())[0] == 0
+
+    async def test_dissolve_zone_is_idempotent(self, repo):
+        """Dissolving an already deleted zone does not fail."""
+        zone = await repo.create_zone("MASTER_001")
+
+        await repo.dissolve_zone(zone.id)
+        await repo.dissolve_zone(zone.id)
+
+        db = repo._ensure_initialized()
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM zones WHERE id = ?",
+            (zone.id,),
+        )
+        assert (await cursor.fetchone())[0] == 0
+
+    async def test_recreate_zone_after_dissolution_gets_new_id(self, repo):
+        """Recreating a dissolved zone creates a new database row."""
+        old_zone = await repo.create_zone("MASTER_001")
+        old_zone_id = old_zone.id
+
+        await repo.dissolve_zone(old_zone_id)
+        new_zone = await repo.create_zone("MASTER_001")
+
+        assert new_zone.id is not None
+        assert new_zone.id != old_zone_id
+
+    async def test_startup_cleanup_removes_previously_dissolved_zones(self, repo):
+        """Startup migration removes legacy soft-deleted zones and members."""
+        db = repo._ensure_initialized()
+
+        cursor = await db.execute(
+            """
+            INSERT INTO zones (master_device_id, created_at, dissolved_at)
+            VALUES (?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            """,
+            ("OLD_MASTER",),
+        )
+        old_zone_id = cursor.lastrowid
+        assert old_zone_id is not None
+
+        await db.execute(
+            """
+            INSERT INTO zone_members (zone_id, device_id, role, added_at)
+            VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+            """,
+            (old_zone_id, "OLD_MASTER", "master"),
+        )
+
+        # Simulate a database that predates cleanup migrations 205/206.
+        await db.execute(
+            "DELETE FROM schema_versions WHERE version IN (205, 206)"
+        )
+        await db.commit()
+
+        db_path = repo.db_path
+        await repo.close()
+
+        reopened = ZoneRepository(db_path)
+        await reopened.initialize()
+        try:
+            reopened_db = reopened._ensure_initialized()
+
+            cursor = await reopened_db.execute(
+                "SELECT COUNT(*) FROM zones WHERE id = ?",
+                (old_zone_id,),
+            )
+            assert (await cursor.fetchone())[0] == 0
+
+            cursor = await reopened_db.execute(
+                "SELECT COUNT(*) FROM zone_members WHERE zone_id = ?",
+                (old_zone_id,),
+            )
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await reopened.close()
+
+    async def test_dissolve_zone_with_no_members(self, repo):
+        """Dissolving a zone with no members still deletes the zone."""
+        zone = await repo.create_zone("MASTER_001")
+        db = repo._ensure_initialized()
+
+        await db.execute(
+            "DELETE FROM zone_members WHERE zone_id = ?",
+            (zone.id,),
+        )
+        await db.commit()
+
+        await repo.dissolve_zone(zone.id)
+
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM zones WHERE id = ?",
+            (zone.id,),
+        )
+        assert (await cursor.fetchone())[0] == 0
+
+    async def test_concurrent_dissolve_zone_is_safe(self, repo):
+        """Concurrent dissolution attempts are idempotent and safe."""
+        import asyncio
+
+        zone = await repo.create_zone("MASTER_001")
+        await repo.add_member(zone.id, "SLAVE_001", "slave")
+
+        await asyncio.gather(
+            repo.dissolve_zone(zone.id),
+            repo.dissolve_zone(zone.id),
+        )
+
+        db = repo._ensure_initialized()
+
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM zones WHERE id = ?",
+            (zone.id,),
+        )
+        assert (await cursor.fetchone())[0] == 0
+
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM zone_members WHERE zone_id = ?",
+            (zone.id,),
+        )
+        assert (await cursor.fetchone())[0] == 0
+
+    async def test_dissolve_zone_keeps_device_records(self, repo):
+        """Dissolving a zone must not delete the underlying devices."""
+        device_repo = DeviceRepository(repo.db_path)
+        await device_repo.initialize()
+
+        try:
+            master = Device(
+                device_id="MASTER_001",
+                ip="192.168.1.10",
+                name="Master",
+                model="SoundTouch 10",
+                mac_address="AA:BB:CC:DD:EE:01",
+                firmware_version="27.0.6",
+            )
+            slave = Device(
+                device_id="SLAVE_001",
+                ip="192.168.1.11",
+                name="Slave",
+                model="SoundTouch 10",
+                mac_address="AA:BB:CC:DD:EE:02",
+                firmware_version="27.0.6",
+            )
+
+            await device_repo.upsert(master)
+            await device_repo.upsert(slave)
+
+            zone = await repo.create_zone(master.device_id)
+            await repo.add_member(zone.id, slave.device_id, "slave")
+
+            await repo.dissolve_zone(zone.id)
+
+            assert await device_repo.get_by_device_id(master.device_id) is not None
+            assert await device_repo.get_by_device_id(slave.device_id) is not None
+
+            db = repo._ensure_initialized()
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM zone_members WHERE zone_id = ?",
+                (zone.id,),
+            )
+            assert (await cursor.fetchone())[0] == 0
+        finally:
+            await device_repo.close()
 
     async def test_get_active_zone_by_master(self, repo):
         """Get active zone by master device ID."""


### PR DESCRIPTION
Closes #364

## Summary

Hard-delete dissolved zones and their members from the database instead of keeping soft-deleted records.

## Changes

* Change `ZoneRepository.dissolve_zone()` to delete all related `zone_members` rows and the corresponding `zones` row
* Add two database cleanup migrations (205/206) to remove previously soft-deleted zone members and zones on startup
* Update zone service comments and logging to reflect hard-delete behavior
* Verify that zone-sync/health-check dissolution also removes the corresponding database rows

## Tests

Added and extended backend tests covering:

* hard-delete of the zone row and all related `zone_members`
* idempotent dissolution if a zone has already been deleted
* recreation of a zone after dissolution with a new database row
* startup cleanup of legacy soft-deleted zones
* zones with no remaining members
* concurrent/idempotent dissolution calls
* zone-sync/health-check dissolution after the grace period
* preservation of the underlying device records in the `devices` table

Test results:

* Ruff checks passed
* 68 relevant backend tests passed
* `ZoneRepository` coverage: 96%

Manual verification:

* created and dissolved a zone through the REST API
* verified that `zones` and `zone_members` contained the expected rows before dissolution
* verified that both tables were empty after dissolution
* repeated the same flow through the frontend and confirmed that `/api/zones` returned `[]` and no zone records remained in SQLite

## Notes

* In line with the schema migration note in #364, the `dissolved_at` column is intentionally retained for now. It is still used by the cleanup migrations to identify legacy soft-deleted zones and can be dropped in a future schema migration after this change ships.
* No functional health-check change was required. Zone sync already delegates dissolution to `ZoneRepository.dissolve_zone()`; the updated health-check test verifies that this now removes the corresponding database rows after the grace period.
* No frontend changes were required, as specified in #364. The create/dissolve flow was additionally verified manually through the frontend and against SQLite.
* Idempotent and concurrent dissolution calls are covered by repository tests.
* The underlying device records remain untouched; only zone and zone-member cache records are deleted.
* As requested in the DevOps considerations of #364, I searched the repository for analytics/reporting/history usage and for direct access to the `zones` and `zone_members` tables. I did not find any analytics or reporting code that depends on dissolved zone history.

🤖 Made with AI assistance
