### PR TITLE
fix(about): strip trailing @handle/@email from supporter names

### DIFF
--- a/apps/frontend/src/pages/aboutUtils.test.ts
+++ b/apps/frontend/src/pages/aboutUtils.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for aboutUtils.ts
+ *
+ * Focus: cleanName() — hides everything after an "@" unless the "@"
+ * is the very first character (i.e. a handle like "@Struppie").
+ */
+
+import { describe, it, expect } from "vitest";
+import { cleanName, parseCSVLine, getFontSize, generateGradientColor } from "./aboutUtils";
+
+describe("cleanName", () => {
+  it("leaves plain names untouched", () => {
+    expect(cleanName("Simon")).toBe("Simon");
+    expect(cleanName("Peter St.")).toBe("Peter St.");
+  });
+
+  it("keeps a leading @ handle fully intact", () => {
+    expect(cleanName("@Struppie")).toBe("@Struppie");
+    expect(cleanName("@Eisenvater")).toBe("@Eisenvater");
+  });
+
+  it("strips everything from an email address's @ onward", () => {
+    expect(cleanName("sebasscholz@climatejustice.social")).toBe("sebasscholz");
+  });
+
+  it("strips everything from the first @ onward when it's not at position 0", () => {
+    expect(cleanName("MASTODON: @nightwatch2359@social.tchncs.de")).toBe("MASTODON:");
+  });
+
+  it("trims trailing whitespace left behind after stripping", () => {
+    expect(cleanName("Name @handle")).toBe("Name");
+  });
+
+  it("returns the name unchanged when there is no @ at all", () => {
+    expect(cleanName("Jürgen N.")).toBe("Jürgen N.");
+    expect(cleanName("")).toBe("");
+  });
+
+  it("still converts GitHub profile URLs to @handles (existing behavior)", () => {
+    expect(cleanName("https://github.com/Zimbo88")).toBe("@Zimbo88");
+  });
+
+  it("does not run the @ email at github handle through the @-stripping branch", () => {
+    // GitHub URL branch takes priority and produces "@Zimbo88";
+    // the leading "@" there must NOT be treated as a reason to strip further.
+    expect(cleanName("https://github.com/Zimbo88")).not.toBe("");
+  });
+});
+
+// Sanity checks that these existing helpers still work — kept minimal since
+// they're not the subject of this change but share the file.
+describe("aboutUtils (existing helpers, regression guard)", () => {
+  it("parseCSVLine splits a simple line", () => {
+    expect(parseCSVLine("Simon,one-time,10,0,2024-01-01")).toEqual([
+      "Simon",
+      "one-time",
+      "10",
+      "0",
+      "2024-01-01",
+    ]);
+  });
+
+  it("getFontSize scales between 12 and 32", () => {
+    const supporter = { name: "x", type: "one-time" as const, amount: 10, monthlyAmount: 0, firstSupportDate: "" };
+    const size = getFontSize(supporter, 10);
+    expect(size).toBeGreaterThanOrEqual(12);
+    expect(size).toBeLessThanOrEqual(32);
+  });
+
+  it("generateGradientColor returns an hsl string", () => {
+    expect(generateGradientColor(0, 5)).toMatch(/^hsl\(/);
+  });
+});

--- a/apps/frontend/src/pages/aboutUtils.ts
+++ b/apps/frontend/src/pages/aboutUtils.ts
@@ -95,14 +95,14 @@ export function parseCSVLine(line: string): string[] {
 }
 
 export function getRandomThankYou(isMonthly: boolean, lang: string): string {
-  const currentLang = lang.split("-")[0]; // en-US → en
+  const currentLang = lang.split("-")[0] ?? "en"; // en-US → en
 
   const category = isMonthly ? "monthly" : "regular";
   const categoryPhrases = THANK_YOU_PHRASES[category];
   const phrases = categoryPhrases?.[currentLang] ?? categoryPhrases?.["en"] ?? [];
 
   if (phrases.length === 0) return "Thank you! ☕";
-  return phrases[Math.floor(Math.random() * phrases.length)]; // NOSONAR — non-cryptographic use for UI tooltip randomization
+  return phrases[Math.floor(Math.random() * phrases.length)] ?? "Thank you! ☕"; // NOSONAR — non-cryptographic use for UI tooltip randomization
 }
 
 export function getFontSize(supporter: Supporter, maxAmount: number): number {
@@ -124,5 +124,13 @@ export function cleanName(name: string): string {
   if (name.startsWith("https://github.com/")) {
     return "@" + name.replace("https://github.com/", "");
   }
+
+  const atIndex = name.indexOf("@");
+  // Only strip if "@" is present and NOT the very first character
+  // (leading "@" denotes a handle, e.g. "@Struppie", and stays untouched)
+  if (atIndex > 0) {
+    return name.slice(0, atIndex).trim();
+  }
+
   return name;
 }


### PR DESCRIPTION
Long supporter names containing an email or a "name @handle" suffix overflowed the About page layout. cleanName() now truncates at the first "@" unless it's the leading character (a bare handle like "@Struppie", which stays intact).