### PR TITLE
chore: ignore local tool/worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,12 @@ specs/
 # === Case Management ===
 bugs/
 
+# === Local Tooling ===
+.worktrees/
+.claude/
+.mcp.json
+.serena/
+
 # === SECRET Files ===
 doc
 memories


### PR DESCRIPTION
.claude/, .mcp.json, .serena/, and .worktrees/ are per-machine tool state, not project source, and kept showing up as untracked noise.